### PR TITLE
initial reslilient parser

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -39,6 +39,7 @@ pub fn build(b: *std.Build) void {
     ziggy_exe.root_module.addImport("lsp", lsp.module("lsp"));
 
     const run_exe = b.addRunArtifact(ziggy_exe);
+    if (b.args) |args| run_exe.addArgs(args);
     const run_exe_step = b.step("run", "Run the Ziggy tool");
     run_exe_step.dependOn(&run_exe.step);
 

--- a/editors/helix/languages.toml
+++ b/editors/helix/languages.toml
@@ -24,7 +24,7 @@ injection-regex = "ziggy-schema|zs"
 file-types = ["zs"]
 comment-token = "///"
 indent = { tab-width = 4, unit = "    " }
-formatter = { command = "ziggy" , args = ["fmt", "--schema", "--stdin"] }
+formatter = { command = "ziggy" , args = ["fmt", "-", "--type", "schema"] }
 auto-format = true
 language-servers = [ "ziggy-schema-lsp" ]
 

--- a/src/cli/check.zig
+++ b/src/cli/check.zig
@@ -98,12 +98,13 @@ fn checkFile(
     const doc_ast = ziggy.Ast.init(
         arena,
         doc_file,
-        false,
+        true,
         true,
         &diag,
     ) catch fatalDiag(diag);
 
-    schema.check(arena, doc_ast, &diag) catch fatalDiag(diag);
+    schema.check(arena, doc_ast, &diag, doc_file) catch fatalDiag(diag);
+    std.debug.print("{}\n", .{diag});
 }
 
 fn fatalDiag(diag: anytype) noreturn {

--- a/src/cli/check.zig
+++ b/src/cli/check.zig
@@ -99,6 +99,7 @@ fn checkFile(
         arena,
         doc_file,
         false,
+        true,
         &diag,
     ) catch fatalDiag(diag);
 

--- a/src/cli/fmt.zig
+++ b/src/cli/fmt.zig
@@ -32,10 +32,12 @@ pub fn run(gpa: std.mem.Allocator, args: []const []const u8) !void {
         try out.print("{}", .{ast});
     } else {
         var diag: Diagnostic = .{ .path = null };
-        const ast = Ast.init(gpa, code, true, &diag) catch {
+        const ast = try Ast.init(gpa, code, true, false, &diag);
+
+        if (diag.errors.items.len != 0) {
             std.debug.print("{}", .{diag});
             std.process.exit(1);
-        };
+        }
 
         try out.print("{}", .{ast});
     }

--- a/src/cli/fmt.zig
+++ b/src/cli/fmt.zig
@@ -37,7 +37,7 @@ pub fn run(gpa: std.mem.Allocator, args: []const []const u8) !void {
 
             const schema = loadSchema(gpa, cmd.schema);
 
-            try schema.check(gpa, doc, &diag);
+            try schema.check(gpa, doc, &diag, code);
 
             if (diag.errors.items.len != 0) {
                 std.debug.print("{}", .{diag});

--- a/src/cli/fmt.zig
+++ b/src/cli/fmt.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const ziggy = @import("ziggy");
-const schema = ziggy.schema;
 const Diagnostic = ziggy.Diagnostic;
 const Ast = ziggy.Ast;
 
@@ -15,43 +14,127 @@ pub fn run(gpa: std.mem.Allocator, args: []const []const u8) !void {
     var buf = std.ArrayList(u8).init(gpa);
     defer buf.deinit();
 
-    try in.readAllArrayList(&buf, 4 * 1024 * 1024 * 1024);
+    try in.readAllArrayList(&buf, ziggy.max_size);
 
     const code = try buf.toOwnedSliceSentinel(0);
 
     var out_buffer = std.io.bufferedWriter(std.io.getStdOut().writer());
     const out = out_buffer.writer();
 
-    if (cmd.schema) {
-        var diag: schema.Diagnostic = .{ .path = null };
-        const ast = schema.Ast.init(gpa, code, &diag) catch {
-            std.debug.print("{}", .{diag});
-            std.process.exit(1);
-        };
+    switch (cmd.fmt_type) {
+        .schema => {
+            var diag: ziggy.schema.Diagnostic = .{ .path = null };
+            const ast = ziggy.schema.Ast.init(gpa, code, &diag) catch {
+                std.debug.print("{}", .{diag});
+                std.process.exit(1);
+            };
 
-        try out.print("{}", .{ast});
-    } else {
-        var diag: Diagnostic = .{ .path = null };
-        const ast = try Ast.init(gpa, code, true, false, &diag);
+            try out.print("{}", .{ast});
+        },
+        .doc, .unset => {
+            var diag: Diagnostic = .{ .path = null };
+            const doc = try Ast.init(gpa, code, true, false, &diag);
 
-        if (diag.errors.items.len != 0) {
-            std.debug.print("{}", .{diag});
-            std.process.exit(1);
-        }
+            const schema = loadSchema(gpa, cmd.schema);
 
-        try out.print("{}", .{ast});
+            try schema.check(gpa, doc, &diag);
+
+            if (diag.errors.items.len != 0) {
+                std.debug.print("{}", .{diag});
+                std.process.exit(1);
+            }
+
+            try out.print("{}", .{doc});
+        },
     }
     try out_buffer.flush();
 }
 
+fn loadSchema(gpa: std.mem.Allocator, path: ?[]const u8) ziggy.schema.Schema {
+    const p = path orelse return defaultSchema();
+
+    var diag: ziggy.schema.Diagnostic = .{ .path = p };
+
+    const schema_file = std.fs.cwd().readFileAllocOptions(
+        gpa,
+        p,
+        ziggy.max_size,
+        null,
+        1,
+        0,
+    ) catch |err| {
+        std.debug.print("error while reading the --schema file: {s}\n\n", .{
+            @errorName(err),
+        });
+        std.process.exit(1);
+    };
+
+    const schema_ast = ziggy.schema.Ast.init(
+        gpa,
+        schema_file,
+        &diag,
+    ) catch |err| {
+        std.debug.print("error while parsing the --schema file: {s}\n\n", .{
+            @errorName(err),
+        });
+        std.debug.print("{}\n", .{diag});
+        std.process.exit(1);
+    };
+
+    const schema = ziggy.schema.Schema.init(
+        gpa,
+        schema_ast.nodes.items,
+        schema_file,
+        &diag,
+    ) catch |err| {
+        std.debug.print("error while parsing the --schema file: {s}\n\n", .{
+            @errorName(err),
+        });
+        std.debug.print("{}\n", .{diag});
+        std.process.exit(1);
+    };
+
+    return schema;
+}
+
+fn defaultSchema() ziggy.schema.Schema {
+    return .{
+        .root = .{ .node = 1 },
+        .code = "any",
+        .allows_unknown_literals = true,
+        .nodes = &.{
+            .{
+                .tag = .root,
+                .loc = .{
+                    .start = 0,
+                    .end = "any".len,
+                },
+                .parent_id = 0,
+            },
+            .{
+                .tag = .any,
+                .loc = .{
+                    .start = 0,
+                    .end = "any".len,
+                },
+                .parent_id = 0,
+            },
+        },
+    };
+}
+
 pub const Command = struct {
     check: bool = false,
-    schema: bool = false,
+    schema: ?[]const u8 = null,
+    fmt_type: FmtType = .unset,
+
     mode: union(enum) {
         unknown,
         stdin,
         paths: []const []const u8,
     } = .unknown,
+
+    const FmtType = enum { unset, doc, schema };
 
     fn parse(args: []const []const u8) Command {
         var cmd: Command = .{};
@@ -75,12 +158,37 @@ pub const Command = struct {
             }
 
             if (std.mem.eql(u8, arg, "--schema")) {
-                if (cmd.check) {
-                    std.debug.print("error: duplicate '--schema' flag\n\n", .{});
+                if (cmd.schema != null) {
+                    std.debug.print("error: duplicate '--schema' option\n\n", .{});
                     std.process.exit(1);
                 }
 
-                cmd.schema = true;
+                idx += 1;
+                if (idx == args.len) {
+                    std.debug.print("error: missing '--schema' option value\n\n", .{});
+                    std.process.exit(1);
+                }
+
+                cmd.schema = args[idx];
+                continue;
+            }
+
+            if (std.mem.eql(u8, arg, "--type")) {
+                if (cmd.fmt_type != .unset) {
+                    std.debug.print("error: duplicate '--type' option\n\n", .{});
+                    std.process.exit(1);
+                }
+
+                idx += 1;
+                if (idx == args.len) {
+                    std.debug.print("error: missing '--type' option value\n\n", .{});
+                    std.process.exit(1);
+                }
+
+                cmd.fmt_type = std.meta.stringToEnum(FmtType, args[idx]) orelse {
+                    std.debug.print("error: invalid '--type' option value, expected 'doc' or 'schema'\n\n", .{});
+                    std.process.exit(1);
+                };
                 continue;
             }
 
@@ -125,6 +233,11 @@ pub const Command = struct {
             fatalHelp();
         }
 
+        if (cmd.fmt_type == .schema and cmd.schema != null) {
+            std.debug.print("error: '--type schema' and --schema are mutually exclusive\n", .{});
+            std.process.exit(1);
+        }
+
         return cmd;
     }
 
@@ -137,14 +250,23 @@ pub const Command = struct {
             \\
             \\Options:
             \\
-            \\--stdin, -       Format bytes from stdin; ouptut to stdout 
-            \\--schema         Set the file format to Ziggy Schema. When
-            \\                 not specified, the file format is inferred
-            \\                 from the file extension. Required when 
-            \\                 formatting Ziggy Schema files with '--stdin'.
-            \\--check          List non-conforming files and exit with an
-            \\                 error if the list is not empty
-            \\--help, -h       Prints this help and extits
+            \\--stdin, -         Format bytes from stdin and ouptut to stdout,
+            \\                   defaults to assuming --type is 'doc'. Mutually
+            \\                   exclusive with the presence of PATH arguments.    
+            \\
+            \\--type doc|schema  Sets the type of file(s) being formatted. When
+            \\                   PATH is a file, the file extension will be 
+            \\                   ignored. When PATH is a directory, makes the 
+            \\                   command only format files of the corresponding
+            \\                   type by checking their file extension.
+            \\
+            \\--schema PATH      Path to a Ziggy schema file that will be used
+            \\                   to check all Ziggy doc files.
+            \\                  
+            \\--check            List non-conforming files and exit with an
+            \\                   error if the list is not empty.
+            \\
+            \\--help, -h         Prints this help and extits.
         , .{});
 
         std.process.exit(1);

--- a/src/cli/logging.zig
+++ b/src/cli/logging.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const folders = @import("known-folders");
 
-var log_file: ?std.fs.File = switch (builtin.target.os.tag) {
+pub var log_file: ?std.fs.File = switch (builtin.target.os.tag) {
     .linux, .macos => std.io.getStdErr(),
     else => null,
 };

--- a/src/cli/lsp/Document.zig
+++ b/src/cli/lsp/Document.zig
@@ -113,11 +113,10 @@ pub fn init(gpa: std.mem.Allocator, bytes: [:0]const u8) error{OutOfMemory}!Docu
     return doc;
 }
 
-fn findSchemaPath(ast: ziggy.Ast, bytes: [:0]const u8) ?[]const u8 {
-    const top_comments = ast.nodes[1];
-    if (top_comments.tag == .top_comment) {
-        assert(top_comments.first_child_id != 0);
-        const schema_line = ast.nodes[top_comments.first_child_id];
+fn findSchemaPath(tree: ziggy.Ast.Tree, bytes: [:0]const u8) ?[]const u8 {
+    const top_comments = tree.children.items[0];
+    if (top_comments == .token and top_comments.token.tag == .top_comment_line) {
+        const schema_line = top_comments.token;
         const src = schema_line.loc.src(bytes);
         var it = std.mem.tokenizeScalar(u8, src, ' ');
         var state: enum { start, comment, schema, colon } = .start;

--- a/src/cli/lsp/Document.zig
+++ b/src/cli/lsp/Document.zig
@@ -108,7 +108,7 @@ pub fn init(gpa: std.mem.Allocator, bytes: [:0]const u8) error{OutOfMemory}!Docu
     };
 
     log.debug("schema: applying", .{});
-    rules.check(arena, ast, &doc.diagnostic) catch return doc;
+    rules.check(arena, ast, &doc.diagnostic, bytes) catch return doc;
 
     return doc;
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -15,31 +15,31 @@ pub const std_options: std.Options = .{
     .logFn = logging.logFn,
 };
 
-// pub fn panic(
-//     msg: []const u8,
-//     trace: ?*std.builtin.StackTrace,
-//     ret_addr: ?usize,
-// ) noreturn {
-//     std.log.err("{s}\n\n{?}", .{ msg, trace });
-//     blk: {
-//         const out = logging.log_file orelse break :blk;
-//         const w = out.writer();
-//         if (builtin.strip_debug_info) {
-//             w.print("Unable to dump stack trace: debug info stripped\n", .{}) catch return;
-//             break :blk;
-//         }
-//         const debug_info = std.debug.getSelfDebugInfo() catch |err| {
-//             w.print("Unable to dump stack trace: Unable to open debug info: {s}\n", .{@errorName(err)}) catch break :blk;
-//             break :blk;
-//         };
-//         std.debug.writeCurrentStackTrace(w, debug_info, .no_color, ret_addr) catch |err| {
-//             w.print("Unable to dump stack trace: {s}\n", .{@errorName(err)}) catch break :blk;
-//             break :blk;
-//         };
-//     }
-//     if (builtin.mode == .Debug) @breakpoint();
-//     std.process.exit(1);
-// }
+pub fn panic(
+    msg: []const u8,
+    trace: ?*std.builtin.StackTrace,
+    ret_addr: ?usize,
+) noreturn {
+    std.log.err("{s}\n\n{?}", .{ msg, trace });
+    blk: {
+        const out = logging.log_file orelse break :blk;
+        const w = out.writer();
+        if (builtin.strip_debug_info) {
+            w.print("Unable to dump stack trace: debug info stripped\n", .{}) catch return;
+            break :blk;
+        }
+        const debug_info = std.debug.getSelfDebugInfo() catch |err| {
+            w.print("Unable to dump stack trace: Unable to open debug info: {s}\n", .{@errorName(err)}) catch break :blk;
+            break :blk;
+        };
+        std.debug.writeCurrentStackTrace(w, debug_info, .no_color, ret_addr) catch |err| {
+            w.print("Unable to dump stack trace: {s}\n", .{@errorName(err)}) catch break :blk;
+            break :blk;
+        };
+    }
+    if (builtin.mode == .Debug) @breakpoint();
+    std.process.exit(1);
+}
 
 pub const Command = enum { lsp, query, fmt, check, convert, help };
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -15,16 +15,31 @@ pub const std_options: std.Options = .{
     .logFn = logging.logFn,
 };
 
-pub fn panic(
-    msg: []const u8,
-    trace: ?*std.builtin.StackTrace,
-    ret_addr: ?usize,
-) noreturn {
-    _ = ret_addr;
-    std.log.err("{s}\n\n{?}", .{ msg, trace });
-    if (builtin.mode == .Debug) @breakpoint();
-    std.process.exit(1);
-}
+// pub fn panic(
+//     msg: []const u8,
+//     trace: ?*std.builtin.StackTrace,
+//     ret_addr: ?usize,
+// ) noreturn {
+//     std.log.err("{s}\n\n{?}", .{ msg, trace });
+//     blk: {
+//         const out = logging.log_file orelse break :blk;
+//         const w = out.writer();
+//         if (builtin.strip_debug_info) {
+//             w.print("Unable to dump stack trace: debug info stripped\n", .{}) catch return;
+//             break :blk;
+//         }
+//         const debug_info = std.debug.getSelfDebugInfo() catch |err| {
+//             w.print("Unable to dump stack trace: Unable to open debug info: {s}\n", .{@errorName(err)}) catch break :blk;
+//             break :blk;
+//         };
+//         std.debug.writeCurrentStackTrace(w, debug_info, .no_color, ret_addr) catch |err| {
+//             w.print("Unable to dump stack trace: {s}\n", .{@errorName(err)}) catch break :blk;
+//             break :blk;
+//         };
+//     }
+//     if (builtin.mode == .Debug) @breakpoint();
+//     std.process.exit(1);
+// }
 
 pub const Command = enum { lsp, query, fmt, check, convert, help };
 
@@ -47,7 +62,7 @@ pub fn main() void {
     _ = switch (cmd) {
         .lsp => lsp_exe.run(gpa, args[2..]),
         .fmt => fmt_exe.run(gpa, args[2..]),
-        .check => check_exe.run(gpa, args[2..]),
+        // .check => check_exe.run(gpa, args[2..]),
         .help => fatalHelp(),
         else => @panic("TODO"),
     } catch |err| fatal("{s}\n", .{@errorName(err)});

--- a/src/main.zig
+++ b/src/main.zig
@@ -62,9 +62,9 @@ pub fn main() void {
     _ = switch (cmd) {
         .lsp => lsp_exe.run(gpa, args[2..]),
         .fmt => fmt_exe.run(gpa, args[2..]),
-        // .check => check_exe.run(gpa, args[2..]),
+        .check => check_exe.run(gpa, args[2..]),
         .help => fatalHelp(),
-        else => @panic("TODO"),
+        else => std.debug.panic("TODO cmd={s}", .{@tagName(cmd)}),
     } catch |err| fatal("{s}\n", .{@errorName(err)});
 }
 

--- a/src/root.zig
+++ b/src/root.zig
@@ -12,11 +12,11 @@ pub const max_size = 4 * 1024 * 1024 * 1024;
 
 test {
     _ = Tokenizer;
-    _ = Parser;
-    _ = Diagnostic;
+    // _ = Parser;
+    // _ = Diagnostic;
     _ = Ast;
-    _ = Value;
-    _ = serializer;
+    // _ = Value;
+    // _ = serializer;
 }
 
 pub const schema = struct {
@@ -26,9 +26,9 @@ pub const schema = struct {
     pub const Ast = @import("schema/Ast.zig");
 };
 
-test {
-    _ = schema.Diagnostic;
-    _ = schema.Tokenizer;
-    _ = schema.Schema;
-    _ = schema.Ast;
-}
+// test {
+//     _ = schema.Diagnostic;
+//     _ = schema.Tokenizer;
+//     _ = schema.Schema;
+//     _ = schema.Ast;
+// }

--- a/src/root.zig
+++ b/src/root.zig
@@ -15,8 +15,10 @@ test {
     // _ = Parser;
     // _ = Diagnostic;
     _ = Ast;
+
     // _ = Value;
     // _ = serializer;
+    _ = @import("ziggy/ResilientParser.zig");
 }
 
 pub const schema = struct {

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,7 +1,7 @@
 pub const Tokenizer = @import("ziggy/Tokenizer.zig");
 pub const Parser = @import("ziggy/Parser.zig");
 pub const Value = @import("ziggy/Value.zig");
-pub const Ast = @import("ziggy/Ast.zig");
+pub const Ast = @import("ziggy/ResilientParser.zig");
 pub const Diagnostic = @import("ziggy/Diagnostic.zig");
 pub const parseLeaky = Parser.parseLeaky;
 pub const serializer = @import("ziggy/serializer.zig");
@@ -18,7 +18,6 @@ test {
 
     // _ = Value;
     // _ = serializer;
-    _ = @import("ziggy/ResilientParser.zig");
 }
 
 pub const schema = struct {

--- a/src/schema/Schema.zig
+++ b/src/schema/Schema.zig
@@ -315,7 +315,7 @@ pub fn check(
     gpa: std.mem.Allocator,
     doc: ziggy.Ast.Tree,
     diag: ?*ziggy.Diagnostic,
-    code: [:0]const u8,
+    ziggy_code: [:0]const u8,
 ) !void {
 
     // TODO: check ziggy file against this ruleset
@@ -327,7 +327,7 @@ pub fn check(
         const items = doc.children.items;
         assert(items[0] == .token);
         const first_child = items[0].token;
-        log.debug("first_child={s}", .{first_child.loc.src(code)});
+        log.debug("first_child={s}", .{first_child.loc.src(ziggy_code)});
         while (items[doc_root_val] == .token and
             items[doc_root_val].token.tag == .top_comment_line) : (doc_root_val += 1)
         {}
@@ -445,13 +445,13 @@ pub fn check(
                         });
                     }
 
-                    const struct_name = struct_name_node.token.loc.src(code);
+                    const struct_name = struct_name_node.token.loc.src(ziggy_code);
 
                     var ident_id = rule.first_child_id;
                     assert(ident_id != 0);
                     while (ident_id != 0) {
                         const id_rule = self.nodes[ident_id];
-                        const id_rule_src = id_rule.loc.src(code);
+                        const id_rule_src = id_rule.loc.src(ziggy_code);
                         if (std.mem.eql(u8, struct_name, id_rule_src)) {
                             try stack.append(.{
                                 .rule = .{ .node = ident_id },
@@ -495,7 +495,7 @@ pub fn check(
                         assert(field.tree.tag == .struct_field);
 
                         const field_name_node = field.tree.children.items[1];
-                        const field_name = field_name_node.token.loc.src(code);
+                        const field_name = field_name_node.token.loc.src(ziggy_code);
 
                         const field_rule = struct_rule.fields.get(field_name) orelse {
                             try addError(gpa, diag, .{

--- a/src/schema/Schema.zig
+++ b/src/schema/Schema.zig
@@ -13,6 +13,7 @@ const log = std.log.scoped(.schema);
 root: Rule,
 code: [:0]const u8,
 nodes: []const Ast.Node,
+allows_unknown_literals: bool = false,
 literals: std.StringHashMapUnmanaged(LiteralRule) = .{},
 structs: std.StringArrayHashMapUnmanaged(StructRule) = .{},
 

--- a/src/schema/Schema.zig
+++ b/src/schema/Schema.zig
@@ -299,7 +299,7 @@ fn analyzeRule(
 const CheckItem = struct {
     optional: bool = false,
     rule: Rule,
-    doc_node: u32,
+    child: ziggy.Ast.Child,
 };
 
 fn addError(gpa: std.mem.Allocator, diag: ?*ziggy.Diagnostic, err: ziggy.Diagnostic.Error) !void {
@@ -313,54 +313,58 @@ fn addError(gpa: std.mem.Allocator, diag: ?*ziggy.Diagnostic, err: ziggy.Diagnos
 pub fn check(
     self: Schema,
     gpa: std.mem.Allocator,
-    doc: ziggy.Ast,
+    doc: ziggy.Ast.Tree,
     diag: ?*ziggy.Diagnostic,
+    code: [:0]const u8,
 ) !void {
+
     // TODO: check ziggy file against this ruleset
     var stack = std.ArrayList(CheckItem).init(gpa);
     defer stack.deinit();
 
-    var doc_root_val: u32 = 1;
-    if (doc.nodes[1].tag == .top_comment) {
-        doc_root_val = doc.nodes[1].next_id;
+    var doc_root_val: u32 = 0;
+    {
+        const items = doc.children.items;
+        assert(items[0] == .token);
+        const first_child = items[0].token;
+        log.debug("first_child={s}", .{first_child.loc.src(code)});
+        while (items[doc_root_val] == .token and
+            items[doc_root_val].token.tag == .top_comment_line) : (doc_root_val += 1)
+        {}
+        try stack.append(.{
+            .rule = self.root,
+            .child = items[doc_root_val],
+        });
     }
-
-    try stack.append(.{
-        .rule = self.root,
-        .doc_node = doc_root_val,
-    });
 
     while (stack.popOrNull()) |elem| {
         const rule = self.nodes[elem.rule.node];
-        const doc_node = doc.nodes[elem.doc_node];
-        {
-            log.debug("rule '{s}', node '{s}'", .{
-                rule.loc.src(self.code),
-                @tagName(doc_node.tag),
-            });
-            const sel = doc_node.loc.getSelection(doc.code);
-            log.debug("line: {}, col: {}", .{
-                sel.start.line,
-                sel.start.col,
-            });
-        }
+        assert(elem.child == .tree);
+        const tree = elem.child.tree;
 
-        if (doc_node.tag == .value and doc_node.missing) {
-            const rule_src = rule.loc.src(self.code);
-            try addError(gpa, diag, .{
-                .missing = .{
-                    .token = .{
-                        .tag = .identifier,
-                        .loc = doc_node.loc,
-                    },
-                    .expected = rule_src,
-                },
-            });
-            continue;
-        }
+        log.debug(
+            "rule {s} {s}, child {}",
+            .{ @tagName(rule.tag), rule.loc.src(self.code), elem.child },
+        );
+
+        // TODO indicate missing
+        // if (doc_node.tag == .value and doc_node.missing) {
+        //     const rule_src = rule.loc.src(code);
+        //     try addError(gpa, diag, .{
+        //         .missing = .{
+        //             .token = .{
+        //                 .tag = .identifier,
+        //                 .loc = doc_node.loc,
+        //             },
+        //             .expected = rule_src,
+        //         },
+        //     });
+        //     continue;
+        // }
 
         switch (rule.tag) {
-            .optional => switch (doc_node.tag) {
+            else => std.debug.panic("TODO {s}", .{@tagName(rule.tag)}),
+            .optional => switch (tree.tag) {
                 .null => {},
                 else => {
                     const child_rule: Rule = .{ .node = rule.first_child_id };
@@ -369,64 +373,71 @@ pub fn check(
                     try stack.append(.{
                         .optional = true,
                         .rule = child_rule,
-                        .doc_node = elem.doc_node,
+                        .child = elem.child,
                     });
                 },
             },
-            .array => switch (doc_node.tag) {
+            .array => switch (tree.tag) {
                 .array => {
                     //TODO: optimize for simple cases
                     const child_rule: Rule = .{ .node = rule.first_child_id };
                     assert(child_rule.node != 0);
 
-                    var doc_child_id = doc_node.first_child_id;
-                    while (doc_child_id != 0) {
-                        assert(doc.nodes[doc_child_id].tag != .comment);
+                    const items = tree.children.items;
+                    assert(items[items.len - 1].token.tag == .rsb);
+                    // start at 1 to skip first token: '['
+                    var child_id: usize = 1;
+                    while (child_id < items.len - 1) : (child_id += 2) {
+                        const arr_child = items[child_id];
+                        if (arr_child == .token) {
+                            assert(arr_child.token.tag != .comment);
+                        }
                         try stack.append(.{
                             .rule = child_rule,
-                            .doc_node = doc_child_id,
+                            .child = arr_child,
                         });
-
-                        doc_child_id = doc.nodes[doc_child_id].next_id;
                     }
                 },
-                else => try self.typeMismatch(gpa, diag, doc, elem),
+                else => try self.typeMismatch(gpa, diag, elem),
             },
-            .map => switch (doc_node.tag) {
-                .struct_or_map => {},
+            .map => switch (tree.tag) {
                 .map => {
                     //TODO: optimize for simple cases
                     const child_rule: Rule = .{ .node = rule.first_child_id };
                     assert(child_rule.node != 0);
-
-                    var doc_child_id = doc_node.first_child_id;
-                    while (doc_child_id != 0) {
-                        assert(doc.nodes[doc_child_id].tag == .map_field);
+                    // maps look like this:
+                    //   '{',
+                    //        fieldname, ':', value, ','
+                    //        fieldname, ':', value, ','?
+                    //   '}'
+                    // in order to iterate values, we start at 3 to skip
+                    // leading curly, fieldname and colon and increment by 4
+                    var child_id: usize = 3;
+                    while (child_id < tree.children.items.len) : (child_id += 4) {
+                        const map_child = tree.children.items[child_id];
+                        log.debug("map_child {}", .{map_child});
                         try stack.append(.{
                             .rule = child_rule,
-                            .doc_node = doc.nodes[doc_child_id].last_child_id,
+                            .child = map_child,
                         });
-
-                        doc_child_id = doc.nodes[doc_child_id].next_id;
                     }
                 },
-
-                else => try self.typeMismatch(gpa, diag, doc, elem),
+                else => try self.typeMismatch(gpa, diag, elem),
             },
-            .struct_union => switch (doc_node.tag) {
+            .struct_union => switch (tree.tag) {
                 .@"struct" => {
                     const rule_src = rule.loc.src(self.code);
-
-                    const struct_name_node = doc.nodes[doc_node.first_child_id];
-                    if (struct_name_node.tag != .identifier) {
+                    const struct_name_node = tree.children.items[0];
+                    assert(struct_name_node == .token);
+                    if (struct_name_node.token.tag != .identifier) {
                         try addError(gpa, diag, .{
                             .missing = .{
                                 .token = .{
                                     .tag = .identifier,
                                     .loc = .{
                                         // a struct always has curlies
-                                        .start = doc_node.loc.start -| 1,
-                                        .end = doc_node.loc.start + 1,
+                                        .start = tree.children.items[0].token.loc.start -| 1,
+                                        .end = tree.children.items[0].token.loc.start + 1,
                                     },
                                 },
                                 .expected = rule_src,
@@ -434,17 +445,17 @@ pub fn check(
                         });
                     }
 
-                    const struct_name = struct_name_node.loc.src(doc.code);
+                    const struct_name = struct_name_node.token.loc.src(code);
 
                     var ident_id = rule.first_child_id;
                     assert(ident_id != 0);
                     while (ident_id != 0) {
                         const id_rule = self.nodes[ident_id];
-                        const id_rule_src = id_rule.loc.src(self.code);
+                        const id_rule_src = id_rule.loc.src(code);
                         if (std.mem.eql(u8, struct_name, id_rule_src)) {
                             try stack.append(.{
                                 .rule = .{ .node = ident_id },
-                                .doc_node = elem.doc_node,
+                                .child = elem.child,
                             });
                             continue;
                         }
@@ -455,45 +466,43 @@ pub fn check(
                         .unknown = .{
                             .token = .{
                                 .tag = .identifier,
-                                .loc = struct_name_node.loc,
+                                .loc = struct_name_node.token.loc,
                             },
                             .expected = rule_src,
                         },
                     });
                 },
-                else => try self.typeMismatch(gpa, diag, doc, elem),
+                else => try self.typeMismatch(gpa, diag, elem),
             },
-            .identifier => switch (doc_node.tag) {
-                .@"struct", .braceless_struct => {
+            .identifier => switch (tree.tag) {
+                .@"struct", .top_level_struct => {
                     //TODO: optimize for simple cases
                     const name = rule.loc.src(self.code);
+                    log.debug("struct name={s}", .{name});
                     const struct_rule = self.structs.get(name).?;
 
                     var seen_fields = std.StringHashMap(void).init(gpa);
                     defer seen_fields.deinit();
 
-                    var doc_child_id = doc_node.first_child_id;
-                    if (doc.nodes[doc_child_id].tag == .identifier) {
-                        doc_child_id = doc.nodes[doc_child_id].next_id;
-                    }
+                    var child_id: usize = 0;
+                    if (tree.children.items[0] == .token and
+                        tree.children.items[0].token.tag == .identifier)
+                        child_id += 1;
 
-                    while (doc_child_id != 0) {
-                        const field = doc.nodes[doc_child_id];
-                        doc_child_id = field.next_id;
+                    while (child_id < tree.children.items.len) : (child_id += 2) {
+                        const field = tree.children.items[child_id];
+                        assert(field == .tree);
+                        assert(field.tree.tag == .struct_field);
 
-                        assert(field.tag == .struct_field);
-
-                        const field_name_node = doc.nodes[field.first_child_id];
-                        assert(field_name_node.tag == .identifier);
-
-                        const field_name = field_name_node.loc.src(doc.code);
+                        const field_name_node = field.tree.children.items[1];
+                        const field_name = field_name_node.token.loc.src(code);
 
                         const field_rule = struct_rule.fields.get(field_name) orelse {
                             try addError(gpa, diag, .{
                                 .unknown = .{
                                     .token = .{
                                         .tag = .identifier,
-                                        .loc = field_name_node.loc,
+                                        .loc = field_name_node.token.loc,
                                     },
                                     .expected = &.{},
                                 },
@@ -507,7 +516,8 @@ pub fn check(
 
                         try stack.append(.{
                             .rule = field_rule.rule,
-                            .doc_node = field.last_child_id,
+                            // skip first 3 tokens of struct field: dot, name, equal
+                            .child = field.tree.children.items[3],
                         });
                     }
 
@@ -524,8 +534,8 @@ pub fn check(
                                         .token = .{
                                             .tag = .value, // doesn't matter
                                             .loc = .{
-                                                .start = doc_node.loc.end - 1,
-                                                .end = doc_node.loc.end,
+                                                .start = tree.children.items[0].token.loc.end - 1,
+                                                .end = tree.children.items[0].token.loc.end,
                                             },
                                         },
                                         .expected = k,
@@ -535,30 +545,29 @@ pub fn check(
                         }
                     }
                 },
-                else => try self.typeMismatch(gpa, diag, doc, elem),
+                else => try self.typeMismatch(gpa, diag, elem),
             },
-            .tag => switch (doc_node.tag) {
-                .tag => {},
-                else => try self.typeMismatch(gpa, diag, doc, elem),
+            .tag => switch (tree.tag) {
+                .tag_string => {},
+                else => try self.typeMismatch(gpa, diag, elem),
             },
-            .bytes => switch (doc_node.tag) {
+            .bytes => switch (tree.tag) {
                 .string, .line_string => {},
-                else => try self.typeMismatch(gpa, diag, doc, elem),
+                else => try self.typeMismatch(gpa, diag, elem),
             },
-            .int => switch (doc_node.tag) {
+            .int => switch (tree.tag) {
                 .integer => {},
-                else => try self.typeMismatch(gpa, diag, doc, elem),
+                else => try self.typeMismatch(gpa, diag, elem),
             },
-            .float => switch (doc_node.tag) {
+            .float => switch (tree.tag) {
                 .float => {},
-                else => try self.typeMismatch(gpa, diag, doc, elem),
+                else => try self.typeMismatch(gpa, diag, elem),
             },
-            .bool => switch (doc_node.tag) {
-                .bool => {},
-                else => try self.typeMismatch(gpa, diag, doc, elem),
+            .bool => switch (tree.tag) {
+                .true, .false => {},
+                else => try self.typeMismatch(gpa, diag, elem),
             },
             .any => {},
-            else => unreachable,
         }
     }
 }
@@ -567,7 +576,6 @@ fn typeMismatch(
     self: Schema,
     gpa: std.mem.Allocator,
     diag: ?*ziggy.Diagnostic,
-    doc: ziggy.Ast,
     check_item: CheckItem,
 ) !void {
     var rule_node = self.nodes[check_item.rule.node];
@@ -575,16 +583,18 @@ fn typeMismatch(
         rule_node = self.nodes[rule_node.parent_id];
     }
 
-    const found = doc.nodes[check_item.doc_node];
+    const found_child = check_item.child.tree.children.items[0];
 
-    assert(found.tag != .comment);
-    assert(found.tag != .top_comment);
+    assert(found_child == .token);
+    const found_token = found_child.token;
+    assert(found_token.tag != .comment);
+    assert(found_token.tag != .top_comment_line);
 
     try addError(gpa, diag, .{
         .type_mismatch = .{
             .token = .{
                 .tag = .value,
-                .loc = found.loc,
+                .loc = found_token.loc,
             },
             .expected = rule_node.loc.src(self.code),
         },

--- a/src/ziggy/Ast.zig
+++ b/src/ziggy/Ast.zig
@@ -4,10 +4,14 @@ const std = @import("std");
 const assert = std.debug.assert;
 const Diagnostic = @import("Diagnostic.zig");
 const Tokenizer = @import("Tokenizer.zig");
+const Token = Tokenizer.Token;
+
+const log = std.log.scoped(.ziggy_ast);
 
 pub const Node = struct {
     tag: Tag,
-    loc: Tokenizer.Token.Loc = undefined,
+    loc: Token.Loc = undefined,
+    missing: bool = false,
 
     // 0 = root node (root node has itself as parent)
     parent_id: u32,
@@ -28,8 +32,8 @@ pub const Node = struct {
         identifier,
         map,
         map_field,
+        map_field_key,
         array,
-        array_comma,
         string,
         multiline_string,
         line_string,
@@ -39,565 +43,716 @@ pub const Node = struct {
         null,
         tag,
         comment,
-        _value,
+        value,
+
+        // errros
+        // error_node,
     };
-
-    pub fn addChild(
-        self: *Node,
-        nodes: *std.ArrayList(Node),
-        tag: Node.Tag,
-    ) !*Node {
-        const self_id = self.getId(nodes);
-        const new_child_id: u32 = @intCast(nodes.items.len);
-        if (self.last_child_id != 0) {
-            const child = &nodes.items[self.last_child_id];
-            std.debug.assert(child.next_id == 0);
-
-            child.next_id = new_child_id;
-        }
-        if (self.first_child_id == 0) {
-            std.debug.assert(self.last_child_id == 0);
-            self.first_child_id = new_child_id;
-        }
-
-        self.last_child_id = new_child_id;
-        const child = try nodes.addOne();
-        child.* = .{ .tag = tag, .parent_id = self_id };
-
-        return child;
-    }
-
-    pub fn parent(self: *Node, nodes: *std.ArrayList(Node)) *Node {
-        return &nodes.items[self.parent_id];
-    }
-
-    pub fn getId(self: *Node, nodes: *std.ArrayList(Node)) u32 {
-        const idx: u32 = @intCast(
-            (@intFromPtr(self) - @intFromPtr(nodes.items.ptr)) / @sizeOf(Node),
-        );
-        std.debug.assert(idx < nodes.items.len);
-        return idx;
-    }
 };
 
 code: [:0]const u8,
-nodes: std.ArrayList(Node),
-tokenizer: Tokenizer,
-diag: ?*Diagnostic,
+nodes: []const Node,
 
-pub fn deinit(self: Ast) void {
-    self.nodes.deinit();
+pub fn deinit(self: Ast, gpa: std.mem.Allocator) void {
+    gpa.free(self.nodes);
 }
+
+const Parser = struct {
+    gpa: std.mem.Allocator,
+    code: [:0]const u8,
+    tokenizer: Tokenizer,
+    stop_on_first_error: bool,
+    diagnostic: ?*Diagnostic,
+    nodes: std.ArrayListUnmanaged(Node) = .{},
+    node: *Node = undefined,
+    token: Token = undefined,
+
+    pub fn ast(p: *Parser) !Ast {
+        return .{
+            .code = p.code,
+            .nodes = try p.nodes.toOwnedSlice(p.gpa),
+        };
+    }
+
+    fn peek(p: *Parser) Token.Tag {
+        return p.tokenizer.peek(p.code).tag;
+    }
+
+    fn next(p: *Parser) !void {
+        const token = p.tokenizer.next(p.code);
+        if (token.tag == .invalid) {
+            try p.addError(.{ .invalid_token = .{ .token = token } });
+        }
+        p.token = token;
+    }
+
+    fn must(p: Parser, token: Token, comptime tag: Token.Tag) !void {
+        return p.mustAny(token, &.{tag});
+    }
+
+    fn mustAny(p: Parser, token: Token, comptime tags: []const Token.Tag) !void {
+        for (tags) |t| {
+            if (t == token.tag) break;
+        } else {
+            try p.addError(.{
+                .unexpected_token = .{
+                    .token = token,
+                    .expected = tags,
+                },
+            });
+        }
+    }
+
+    pub fn addError(p: *Parser, err: Diagnostic.Error) !void {
+        if (p.diagnostic) |d| {
+            try d.errors.append(p.gpa, err);
+        } else {
+            return err.zigError();
+        }
+        if (p.stop_on_first_error) return err.zigError();
+    }
+
+    pub fn addChild(p: *Parser, tag: Node.Tag) !void {
+        const n = p.node;
+        const self_id = p.getId();
+        const new_child_id: u32 = @intCast(p.nodes.items.len);
+        if (n.last_child_id != 0) {
+            const child = &p.nodes.items[n.last_child_id];
+            std.debug.assert(child.next_id == 0);
+            child.next_id = new_child_id;
+        }
+        if (n.first_child_id == 0) {
+            std.debug.assert(n.last_child_id == 0);
+            n.first_child_id = new_child_id;
+        }
+
+        n.last_child_id = new_child_id;
+        const child = try p.nodes.addOne(p.gpa);
+        child.* = .{ .tag = tag, .parent_id = self_id };
+
+        p.node = child;
+    }
+
+    pub fn parent(p: *Parser) void {
+        const n = p.node;
+        p.node = &p.nodes.items[n.parent_id];
+    }
+
+    pub fn getId(p: Parser) u32 {
+        const n = p.node;
+        const idx: u32 = @intCast(
+            (@intFromPtr(n) - @intFromPtr(p.nodes.items.ptr)) / @sizeOf(Node),
+        );
+        std.debug.assert(idx < p.nodes.items.len);
+        return idx;
+    }
+};
 
 pub fn init(
     gpa: std.mem.Allocator,
     code: [:0]const u8,
     want_comments: bool,
-    diag: ?*Diagnostic,
+    stop_on_first_error: bool,
+    diagnostic: ?*Diagnostic,
 ) !Ast {
-    var ast: Ast = .{
+    var p: Parser = .{
+        .gpa = gpa,
         .code = code,
-        .diag = diag,
+        .diagnostic = diagnostic,
+        .stop_on_first_error = stop_on_first_error,
         .tokenizer = .{ .want_comments = want_comments },
-        .nodes = std.ArrayList(Node).init(gpa),
     };
-    errdefer ast.nodes.clearAndFree();
 
-    if (ast.diag) |d| {
-        d.code = code;
+    if (p.diagnostic) |d| {
+        d.code = p.code;
     }
 
-    const root_node = try ast.nodes.addOne();
+    errdefer p.nodes.clearAndFree(gpa);
+
+    const root_node = try p.nodes.addOne(gpa);
     root_node.* = .{ .tag = .root, .parent_id = 0 };
 
-    var node = root_node;
-    var token = try ast.next();
+    p.node = root_node;
+    try p.next();
     while (true) {
-        switch (node.tag) {
+        log.debug("entering '{s}'", .{@tagName(p.node.tag)});
+        switch (p.node.tag) {
             .comment, .multiline_string, .top_comment_line, .line_string => unreachable,
-            .root => switch (token.tag) {
+            .root => switch (p.token.tag) {
                 .top_comment_line => {
-                    node = try node.addChild(&ast.nodes, .top_comment);
-                    node.loc.start = token.loc.start;
+                    try p.addChild(.top_comment);
+                    p.node.loc.start = p.token.loc.start;
                 },
                 .dot, .comment => {
-                    node = try node.addChild(&ast.nodes, .braceless_struct);
-                    node.loc.start = token.loc.start;
+                    try p.addChild(.braceless_struct);
+                    p.node.loc.start = p.token.loc.start;
                 },
-                .eof => return ast,
+                .eof => return p.ast(),
                 else => {
-                    node = try node.addChild(&ast.nodes, ._value);
+                    const last_child = p.nodes.items[p.node.last_child_id];
+                    switch (last_child.tag) {
+                        .root, .top_comment => try p.addChild(.value),
+                        else => {
+                            while (p.token.tag != .eof) : (try p.next()) {
+                                try p.addError(.{
+                                    .unexpected_token = .{
+                                        .token = p.token,
+                                        .expected = &.{},
+                                    },
+                                });
+                            }
+                            return p.ast();
+                        },
+                    }
                 },
             },
-            .top_comment => switch (token.tag) {
+            .top_comment => switch (p.token.tag) {
                 .top_comment_line => {
-                    assert(node.tag == .top_comment);
-                    node = try node.addChild(&ast.nodes, .top_comment_line);
-                    node.loc = token.loc;
-                    node = node.parent(&ast.nodes);
-                    node.loc.end = token.loc.end;
-                    token = try ast.next();
+                    try p.addChild(.top_comment_line);
+                    p.node.loc = p.token.loc;
+                    p.parent();
+                    p.node.loc.end = p.token.loc.end;
+                    try p.next();
                 },
-                else => node = node.parent(&ast.nodes),
+                else => p.parent(),
             },
-            .braceless_struct => switch (token.tag) {
+            .braceless_struct => switch (p.token.tag) {
                 .eof => {
-                    node.loc.end = token.loc.end;
-                    return ast;
+                    p.node.loc.end = p.token.loc.end;
+                    return p.ast();
                 },
                 .comment => {
-                    node = try node.addChild(&ast.nodes, .comment);
-                    node.loc = token.loc;
-                    node = node.parent(&ast.nodes);
-                    token = try ast.next();
+                    try p.addChild(.comment);
+                    p.node.loc = p.token.loc;
+                    p.parent();
+                    try p.next();
                 },
-                .dot => {
-                    node = try node.addChild(&ast.nodes, .struct_field);
-                    node.loc.start = token.loc.start;
-                    token = try ast.next();
+                .rb => {
+                    try p.addError(.{
+                        .unexpected_token = .{
+                            .token = p.token,
+                            .expected = &.{},
+                        },
+                    });
+                    try p.next();
                 },
                 else => {
-                    if (ast.diag) |d| {
-                        d.tok = token;
-                        d.err = .{
-                            .unexpected_token = .{
-                                .expected = &.{ .eof, .dot },
-                            },
-                        };
-                    }
-                    return error.Syntax;
+                    try p.addChild(.struct_field);
+                    p.node.loc.start = p.token.loc.start;
                 },
             },
 
-            .struct_or_map => switch (token.tag) {
+            .struct_or_map => switch (p.token.tag) {
                 .comment => {
-                    node = try node.addChild(&ast.nodes, .comment);
-                    node.loc = token.loc;
-                    node = node.parent(&ast.nodes);
-                    token = try ast.next();
+                    try p.addChild(.comment);
+                    p.node.loc = p.token.loc;
+                    p.parent();
+                    try p.next();
                 },
                 .rb => {
-                    node.loc.end = token.loc.end;
-                    node = node.parent(&ast.nodes);
-                    token = try ast.next();
+                    p.node.loc.end = p.token.loc.end;
+                    p.parent();
+                    try p.next();
                 },
                 .dot => {
-                    node.tag = .@"struct";
+                    p.node.tag = .@"struct";
                 },
                 .string => {
-                    node.tag = .map;
+                    p.node.tag = .map;
                 },
                 else => {
-                    if (ast.diag) |d| {
-                        d.tok = token;
-                        d.err = .{
-                            .unexpected_token = .{
-                                .expected = &.{ .dot, .string, .rb },
-                            },
-                        };
-                    }
-                    return error.Syntax;
+                    p.node.loc.end = p.token.loc.start;
+                    p.parent();
+                    try p.addError(.{
+                        .unexpected_token = .{
+                            .token = p.token,
+                            .expected = &.{ .dot, .string, .rb },
+                        },
+                    });
                 },
             },
 
-            .@"struct" => switch (token.tag) {
+            .@"struct" => switch (p.token.tag) {
                 .comment => {
-                    node = try node.addChild(&ast.nodes, .comment);
-                    node.loc = token.loc;
-                    node = node.parent(&ast.nodes);
-                    token = try ast.next();
-                },
-                .dot => {
-                    node = try node.addChild(&ast.nodes, .struct_field);
-                    node.loc.start = token.loc.start;
-                    token = try ast.next();
+                    try p.addChild(.comment);
+                    p.node.loc = p.token.loc;
+                    p.parent();
+                    try p.next();
                 },
                 .rb => {
-                    node.loc.end = token.loc.end;
-                    node = node.parent(&ast.nodes);
-                    token = try ast.next();
+                    p.node.loc.end = p.token.loc.end;
+                    p.parent();
+                    try p.next();
                 },
-                else => {
-                    if (ast.diag) |d| {
-                        d.tok = token;
-                        d.err = .{
-                            .unexpected_token = .{
-                                .expected = &.{ .dot, .rb },
-                            },
-                        };
-                    }
-                    return error.Syntax;
-                },
+                else => try p.addChild(.struct_field),
             },
 
             .struct_field => {
-                if (node.first_child_id == 0) {
-                    if (token.tag == .identifier) {
-                        node = try node.addChild(&ast.nodes, .identifier);
-                        node.loc = token.loc;
-                        node = node.parent(&ast.nodes);
-                    } else {
-                        if (ast.diag) |d| {
-                            d.tok = token;
-                            d.err = .{
+                const last_child = p.nodes.items[p.node.last_child_id];
+                log.debug("last: '{s}'", .{
+                    @tagName(last_child.tag),
+                });
+                switch (last_child.tag) {
+                    .root => {
+                        // first time entering, struct has no children
+                        p.node.loc.start = p.token.loc.start;
+                        if (p.token.tag == .dot) {
+                            try p.next();
+                        } else {
+                            try p.addError(.{
                                 .unexpected_token = .{
-                                    .expected = &.{.identifier},
+                                    .token = p.token,
+                                    .expected = &.{.dot},
                                 },
-                            };
+                            });
                         }
-                        return error.Syntax;
-                    }
 
-                    const t = try ast.next();
-                    if (t.tag != .eql) {
-                        if (ast.diag) |d| {
-                            d.tok = t;
-                            d.err = .{
+                        try p.addChild(.identifier);
+                        if (p.token.tag == .identifier) {
+                            p.node.loc = p.token.loc;
+                            p.parent();
+                            try p.next();
+                        } else {
+                            p.node.missing = true;
+                            p.node.loc.start = p.token.loc.start;
+                            p.node.loc.end = p.node.loc.start;
+                            p.parent();
+                        }
+
+                        // Collect garbage until punctuation
+                        while (true) : (try p.next()) {
+                            log.debug("garbage loop: '{s}'", .{
+                                @tagName(p.token.tag),
+                            });
+                            switch (p.token.tag) {
+                                .eql,
+                                .colon,
+                                // start of a value
+                                .lb,
+                                .lsb,
+                                .at,
+                                .string,
+                                .integer,
+                                .float,
+                                .true,
+                                .false,
+                                .null,
+                                => break,
+                                .identifier => {
+                                    if (p.peek() == .lb) {
+                                        break;
+                                    } else {
+                                        try p.addError(.{
+                                            .unexpected_token = .{
+                                                .token = p.token,
+                                                .expected = &.{},
+                                            },
+                                        });
+                                    }
+                                },
+
+                                .dot, .comma, .rb, .rsb, .eof => {
+                                    p.node.loc.start = p.token.loc.end;
+                                    try p.addChild(.value);
+                                    p.node.missing = true;
+                                    p.node.loc.start = p.token.loc.start;
+                                    p.node.loc.end = p.node.loc.start;
+                                    p.parent();
+                                    p.parent();
+                                    if (p.token.tag == .comma) {
+                                        try p.next();
+                                    }
+                                    break;
+                                },
+                                else => {
+                                    try p.addError(.{
+                                        .unexpected_token = .{
+                                            .token = p.token,
+                                            .expected = &.{},
+                                        },
+                                    });
+                                },
+                            }
+                        }
+                        log.debug("exiting struct_field: '{s}'", .{
+                            @tagName(p.node.tag),
+                        });
+                    },
+                    .identifier => {
+                        log.debug("struct field identifier", .{});
+                        if (p.token.tag == .eql) {
+                            try p.next();
+                        } else {
+                            try p.addError(.{
                                 .unexpected_token = .{
+                                    .token = p.token,
                                     .expected = &.{.eql},
                                 },
-                            };
+                            });
                         }
-                        return error.Syntax;
-                    }
 
-                    node = try node.addChild(&ast.nodes, ._value);
-                    token = try ast.next();
-                } else {
-                    node.loc.end = token.loc.end;
-
-                    if (token.tag == .comma) {
-                        token = try ast.next();
-                    } else {
-                        if (token.tag != .rb and token.tag != .eof) {
-                            if (ast.diag) |d| {
-                                d.tok = token;
-                                d.err = .{
-                                    .unexpected_token = .{
-                                        .expected = &.{.comma},
-                                    },
-                                };
+                        while (true) : (try p.next()) {
+                            switch (p.token.tag) {
+                                else => break,
+                                .identifier => {
+                                    if (p.peek() == .lb) {
+                                        break;
+                                    } else {
+                                        try p.addError(.{
+                                            .unexpected_token = .{
+                                                .token = p.token,
+                                                .expected = &.{},
+                                            },
+                                        });
+                                    }
+                                },
                             }
-                            return error.Syntax;
                         }
-                    }
-
-                    node = node.parent(&ast.nodes);
+                        try p.addChild(.value);
+                    },
+                    else => {
+                        log.debug("struct field final", .{});
+                        // Collect garbage until punctuation
+                        while (true) : (try p.next()) {
+                            switch (p.token.tag) {
+                                .comma => {
+                                    p.node.loc.start = p.token.loc.end;
+                                    p.parent();
+                                    try p.next();
+                                    break;
+                                },
+                                .dot, .rb, .rsb, .eof => {
+                                    p.node.loc.start = p.token.loc.start;
+                                    p.parent();
+                                    break;
+                                },
+                                else => {
+                                    try p.addError(.{
+                                        .unexpected_token = .{
+                                            .token = p.token,
+                                            .expected = &.{.comma},
+                                        },
+                                    });
+                                },
+                            }
+                        }
+                    },
                 }
             },
 
-            .map => switch (token.tag) {
+            .map => switch (p.token.tag) {
                 .comment => {
-                    node = try node.addChild(&ast.nodes, .comment);
-                    node.loc = token.loc;
-                    node = node.parent(&ast.nodes);
-                    token = try ast.next();
+                    try p.addChild(.comment);
+                    p.node.loc = p.token.loc;
+                    p.parent();
+                    try p.next();
                 },
-                .string => {
-                    node = try node.addChild(&ast.nodes, .map_field);
-                    node.loc.start = token.loc.start;
-                },
-                .rb => {
-                    node.loc.end = token.loc.end;
-                    node = node.parent(&ast.nodes);
-                    token = try ast.next();
+                .rb, .eof, .dot => {
+                    if (p.token.tag == .rb) {
+                        p.node.loc.end = p.token.loc.end;
+                        try p.next();
+                    } else {
+                        p.node.loc.end = p.token.loc.start;
+                        try p.addError(.{
+                            .unexpected_token = .{
+                                .token = p.token,
+                                .expected = &.{.rb},
+                            },
+                        });
+                    }
+                    p.parent();
                 },
                 else => {
-                    if (ast.diag) |d| {
-                        d.tok = token;
-                        d.err = .{
-                            .unexpected_token = .{
-                                .expected = &.{ .string, .rb },
-                            },
-                        };
-                    }
-                    return error.Syntax;
+                    try p.addChild(.map_field);
+                    p.node.loc.start = p.token.loc.start;
                 },
             },
 
             .map_field => {
-                if (node.first_child_id == 0) {
-                    if (token.tag == .string) {
-                        node = try node.addChild(&ast.nodes, .string);
-                        node.loc = token.loc;
-                        node = node.parent(&ast.nodes);
-                    } else {
-                        if (ast.diag) |d| {
-                            d.tok = token;
-                            d.err = .{
-                                .unexpected_token = .{
-                                    .expected = &.{.string},
+                const last_child = p.nodes.items[p.node.last_child_id];
+                log.debug(" last: '{s}'", .{@tagName(last_child.tag)});
+                switch (last_child.tag) {
+                    .root => {
+                        p.node.loc.start = p.token.loc.start;
+                        try p.addChild(.map_field_key);
+                        const first_token = p.token;
+                        var found_key = false;
+                        while (true) : (try p.next()) {
+                            switch (p.token.tag) {
+                                .eql, .colon, .comma, .rb => break,
+                                .string => {
+                                    if (found_key) {
+                                        try p.addError(.{
+                                            .unexpected_token = .{
+                                                .token = p.token,
+                                                .expected = &.{ .string, .rb },
+                                            },
+                                        });
+                                    } else {
+                                        found_key = true;
+                                        p.node.loc = p.token.loc;
+                                    }
                                 },
-                            };
+                                else => try p.addError(.{
+                                    .unexpected_token = .{
+                                        .token = p.token,
+                                        .expected = &.{ .string, .rb },
+                                    },
+                                }),
+                            }
                         }
-                        return error.Syntax;
-                    }
 
-                    const t = try ast.next();
-                    if (t.tag != .colon) {
-                        if (ast.diag) |d| {
-                            d.tok = token;
-                            d.err = .{
+                        if (!found_key) {
+                            p.node.missing = true;
+                            p.node.loc.start = first_token.loc.start;
+                            p.node.loc.end = p.node.loc.start + 1;
+                        }
+
+                        p.parent();
+                    },
+                    .map_field_key => {
+                        if (p.token.tag == .colon) {
+                            try p.next();
+                        } else {
+                            try p.addError(.{
                                 .unexpected_token = .{
+                                    .token = p.token,
                                     .expected = &.{.colon},
                                 },
-                            };
+                            });
                         }
-                        return error.Syntax;
-                    }
-
-                    node = try node.addChild(&ast.nodes, ._value);
-                    token = try ast.next();
-                } else {
-                    node.loc.end = token.loc.end;
-                    if (token.tag == .comma) {
-                        token = try ast.next();
-                    } else {
-                        if (token.tag != .rb) {
-                            if (ast.diag) |d| {
-                                d.tok = token;
-                                d.err = .{
+                        try p.addChild(.value);
+                        while (true) : (try p.next()) {
+                            switch (p.token.tag) {
+                                .rsb, .invalid, .colon, .eql => try p.addError(.{
                                     .unexpected_token = .{
-                                        .expected = &.{.comma},
+                                        .token = p.token,
+                                        .expected = &.{.value},
                                     },
-                                };
+                                }),
+                                .identifier => {
+                                    if (p.peek() == .lb) {
+                                        break;
+                                    } else {
+                                        try p.addError(.{
+                                            .unexpected_token = .{
+                                                .token = p.token,
+                                                .expected = &.{},
+                                            },
+                                        });
+                                    }
+                                },
+                                else => break,
                             }
-                            return error.Syntax;
                         }
-                    }
-
-                    node = node.parent(&ast.nodes);
+                    },
+                    else => {
+                        while (true) : (try p.next()) {
+                            switch (p.token.tag) {
+                                .comma => {
+                                    p.node.loc.end = p.token.loc.end;
+                                    p.parent();
+                                    try p.next();
+                                    break;
+                                },
+                                .rb => {
+                                    p.node.loc.end = p.token.loc.start;
+                                    p.parent();
+                                    break;
+                                },
+                                .string => {
+                                    p.node.loc.end = p.token.loc.start;
+                                    try p.addError(.{
+                                        .unexpected_token = .{
+                                            .token = p.token,
+                                            .expected = &.{.comma},
+                                        },
+                                    });
+                                    p.parent();
+                                },
+                                else => try p.addError(.{
+                                    .unexpected_token = .{
+                                        .token = p.token,
+                                        .expected = &.{ .string, .rb },
+                                    },
+                                }),
+                            }
+                        }
+                    },
                 }
             },
             .array => {
-                if (node.last_child_id != 0 and
-                    ast.nodes.items[node.last_child_id].tag != .comment)
+                if (p.node.last_child_id != 0 and
+                    p.nodes.items[p.node.last_child_id].tag != .comment)
                 {
-                    if (token.tag == .comma) {
-                        token = try ast.next();
-                        if (token.tag == .rsb) {
-                            node.tag = .array_comma;
-                        }
+                    if (p.token.tag == .comma) {
+                        try p.next();
                     } else {
-                        if (token.tag != .rsb) {
-                            if (ast.diag) |d| {
-                                d.tok = token;
-                                d.err = .{
-                                    .unexpected_token = .{
-                                        .expected = &.{.comma},
-                                    },
-                                };
-                            }
-                            return error.Syntax;
+                        if (p.token.tag != .rsb) {
+                            try p.addError(.{
+                                .unexpected_token = .{
+                                    .token = p.token,
+                                    .expected = &.{.comma},
+                                },
+                            });
                         }
                     }
                 }
 
-                while (token.tag == .comment) : (token = try ast.next()) {
-                    node = try node.addChild(&ast.nodes, .comment);
-                    node.loc = token.loc;
-                    node = node.parent(&ast.nodes);
+                while (p.token.tag == .comment) : (try p.next()) {
+                    try p.addChild(.comment);
+                    p.node.loc = p.token.loc;
+                    p.parent();
                 }
 
-                if (token.tag == .rsb) {
-                    node.loc.end = token.loc.end;
-                    node = node.parent(&ast.nodes);
-                    token = try ast.next();
+                if (p.token.tag == .rsb) {
+                    p.node.loc.end = p.token.loc.end;
+                    p.parent();
+                    try p.next();
                 } else {
-                    node = try node.addChild(&ast.nodes, ._value);
+                    try p.addChild(.value);
                 }
             },
 
-            ._value => switch (token.tag) {
+            .value => switch (p.token.tag) {
                 .lb => {
-                    node.tag = .struct_or_map;
-                    node.loc.start = token.loc.start;
-                    token = try ast.next();
+                    p.node.tag = .struct_or_map;
+                    p.node.loc.start = p.token.loc.start;
+                    try p.next();
                 },
                 .identifier => {
-                    {
-                        const src = token.loc.src(code);
-                        switch (src[0]) {
-                            'A'...'Z' => {},
-                            else => {
-                                if (ast.diag) |d| {
-                                    d.tok = token;
-                                    d.err = .{
-                                        .unexpected_token = .{
-                                            .expected = &.{.value},
-                                        },
-                                    };
-                                }
-                                return error.Syntax;
-                            },
-                        }
-                    }
-                    node.tag = .struct_or_map;
-                    node.loc.start = token.loc.start;
-                    node = try node.addChild(&ast.nodes, .identifier);
-                    node.loc = token.loc;
-                    node = node.parent(&ast.nodes);
-                    token = try ast.next();
-                    if (token.tag != .lb) {
-                        if (ast.diag) |d| {
-                            d.tok = token;
-                            d.err = .{
-                                .unexpected_token = .{
-                                    .expected = &.{.lb},
-                                },
-                            };
-                        }
-                        return error.Syntax;
-                    }
-                    token = try ast.next();
+                    p.node.tag = .struct_or_map;
+                    p.node.loc.start = p.token.loc.start;
+                    try p.addChild(.identifier);
+                    p.node.loc = p.token.loc;
+                    p.parent();
+                    try p.next();
+                    assert(p.token.tag == .lb);
+                    try p.next();
                 },
                 .lsb => {
-                    node.tag = .array;
-                    node.loc.start = token.loc.start;
-                    token = try ast.next();
+                    p.node.tag = .array;
+                    p.node.loc.start = p.token.loc.start;
+                    try p.next();
                 },
                 .at => {
-                    node.tag = .tag;
-                    node.loc.start = token.loc.start;
+                    p.node.tag = .tag;
+                    p.node.loc.start = p.token.loc.start;
+                    const tag_token = p.token;
 
-                    token = try ast.next();
-                    if (token.tag != .identifier) {
-                        if (ast.diag) |d| {
-                            d.tok = token;
-                            d.err = .{
-                                .unexpected_token = .{
-                                    .expected = &.{.identifier},
-                                },
-                            };
-                        }
-                        return error.Syntax;
+                    try p.next();
+
+                    try p.addChild(.identifier);
+
+                    if (p.token.tag == .identifier) {
+                        p.node.loc = p.token.loc;
+                        p.parent();
+                        p.node.loc.end = p.token.loc.end;
+                        try p.next();
+                    } else {
+                        p.node.missing = true;
+                        p.node.loc = tag_token.loc;
+                        p.parent();
+                        p.node.loc.end = tag_token.loc.end;
                     }
-                    const src = token.loc.src(code);
-                    for (src) |ch| {
-                        switch (ch) {
-                            else => {},
-                            'A'...'Z' => {
-                                if (ast.diag) |d| {
-                                    d.tok = token;
-                                    d.err = .{
-                                        .unexpected_token = .{
-                                            .expected = &.{.tag_name},
-                                        },
-                                    };
-                                }
-                                return error.Syntax;
+
+                    // TODO: make resilient
+
+                    if (p.token.tag != .lp) {
+                        try p.addError(.{
+                            .unexpected_token = .{
+                                .token = p.token,
+                                .expected = &.{.lp},
                             },
-                        }
+                        });
                     }
 
-                    node = try node.addChild(&ast.nodes, .identifier);
-                    node.loc = token.loc;
-                    node = node.parent(&ast.nodes);
-                    node.loc.end = token.loc.end;
+                    try p.next();
+                    if (p.token.tag != .string) {
+                        try p.addError(.{
+                            .unexpected_token = .{
+                                .token = p.token,
+                                .expected = &.{.string},
+                            },
+                        });
+                    }
+                    try p.addChild(.string);
+                    p.node.loc = p.token.loc;
 
-                    token = try ast.next();
-                    if (token.tag != .lp) {
-                        if (ast.diag) |d| {
-                            d.tok = token;
-                            d.err = .{
-                                .unexpected_token = .{
-                                    .expected = &.{.lp},
-                                },
-                            };
-                        }
-                        return error.Syntax;
+                    try p.next();
+                    if (p.token.tag != .rp) {
+                        try p.addError(.{
+                            .unexpected_token = .{
+                                .token = p.token,
+                                .expected = &.{.rp},
+                            },
+                        });
                     }
 
-                    token = try ast.next();
-                    if (token.tag != .string) {
-                        if (ast.diag) |d| {
-                            d.tok = token;
-                            d.err = .{
-                                .unexpected_token = .{
-                                    .expected = &.{.string},
-                                },
-                            };
-                        }
-                        return error.Syntax;
-                    }
-                    node = try node.addChild(&ast.nodes, .string);
-                    node.loc = token.loc;
-
-                    token = try ast.next();
-                    if (token.tag != .rp) {
-                        if (ast.diag) |d| {
-                            d.tok = token;
-                            d.err = .{
-                                .unexpected_token = .{
-                                    .expected = &.{.rp},
-                                },
-                            };
-                        }
-                        return error.Syntax;
-                    }
-
-                    node = node.parent(&ast.nodes).parent(&ast.nodes);
-                    token = try ast.next();
+                    // go up 2 nodes
+                    p.parent();
+                    p.parent();
+                    try p.next();
                 },
                 .string => {
-                    node.tag = .string;
-                    node.loc = token.loc;
-                    node = node.parent(&ast.nodes);
-                    token = try ast.next();
+                    p.node.tag = .string;
+                    p.node.loc = p.token.loc;
+                    p.parent();
+                    try p.next();
                 },
                 .line_string => {
-                    node.tag = .multiline_string;
-                    node.loc.start = token.loc.start;
-                    while (token.tag == .line_string) {
-                        node = try node.addChild(&ast.nodes, .line_string);
-                        node.loc = token.loc;
-                        node = node.parent(&ast.nodes);
-                        node.loc.end = token.loc.end;
-                        token = try ast.next();
+                    p.node.tag = .multiline_string;
+                    p.node.loc.start = p.token.loc.start;
+                    while (p.token.tag == .line_string) {
+                        try p.addChild(.line_string);
+                        p.node.loc = p.token.loc;
+                        p.parent();
+                        p.node.loc.end = p.token.loc.end;
+                        try p.next();
                     }
 
-                    node = node.parent(&ast.nodes);
+                    p.parent();
                 },
                 .integer => {
-                    node.tag = .integer;
-                    node.loc = token.loc;
-                    node = node.parent(&ast.nodes);
-                    token = try ast.next();
+                    p.node.tag = .integer;
+                    p.node.loc = p.token.loc;
+                    p.parent();
+                    try p.next();
                 },
                 .float => {
-                    node.tag = .float;
-                    node.loc = token.loc;
-                    node = node.parent(&ast.nodes);
-                    token = try ast.next();
+                    p.node.tag = .float;
+                    p.node.loc = p.token.loc;
+                    p.parent();
+                    try p.next();
                 },
                 .true, .false => {
-                    node.tag = .bool;
-                    node.loc = token.loc;
-                    node = node.parent(&ast.nodes);
-                    token = try ast.next();
+                    p.node.tag = .bool;
+                    p.node.loc = p.token.loc;
+                    p.parent();
+                    try p.next();
                 },
                 .null => {
-                    node.tag = .null;
-                    node.loc = token.loc;
-                    node = node.parent(&ast.nodes);
-                    token = try ast.next();
+                    p.node.tag = .null;
+                    p.node.loc = p.token.loc;
+                    p.parent();
+                    try p.next();
                 },
                 else => {
-                    if (ast.diag) |d| {
-                        d.tok = token;
-                        d.err = .{
-                            .unexpected_token = .{
-                                .expected = &.{.value},
-                            },
-                        };
-                    }
-                    return error.Syntax;
+                    p.node.tag = .value;
+                    p.node.missing = true;
+                    p.node.loc.start = p.token.loc.start;
+                    p.node.loc.end = p.node.loc.start;
+                    p.parent();
+                    try p.addError(.{
+                        .unexpected_token = .{
+                            .token = p.token,
+                            .expected = &.{.value},
+                        },
+                    });
                 },
             },
 
-            // only set at .rsb
-            .array_comma,
-
+            .map_field_key,
             .tag,
             .identifier,
             .string,
@@ -610,18 +765,6 @@ pub fn init(
     }
 }
 
-fn next(self: *Ast) error{Syntax}!Tokenizer.Token {
-    const token = self.tokenizer.next(self.code);
-    if (token.tag == .invalid) {
-        if (self.diag) |d| {
-            d.tok = token;
-            d.err = .invalid_token;
-        }
-        return error.Syntax;
-    }
-    return token;
-}
-
 pub fn format(
     self: Ast,
     comptime fmt: []const u8,
@@ -631,7 +774,7 @@ pub fn format(
     _ = fmt;
     _ = options;
 
-    try render(self.nodes.items, self.code, out_stream);
+    try render(self.nodes, self.code, out_stream);
 }
 
 const RenderMode = enum { horizontal, vertical };
@@ -747,20 +890,22 @@ fn renderValue(
                 try w.writeAll("[]");
                 return;
             }
-            const mode: RenderMode = if (hasMultilineSiblings(node.first_child_id, nodes)) blk: {
-                break :blk .vertical;
-            } else .horizontal;
+            const mode: RenderMode = if (hasMultilineSiblings(node.first_child_id, nodes))
+                .vertical
+            else blk: {
+                const start = nodes[node.last_child_id].loc.end;
+                const end = node.loc.end;
+                if (std.mem.indexOfScalar(u8, code[start..end], ',') != null) {
+                    break :blk .vertical;
+                }
+                break :blk .horizontal;
+            };
 
-            try w.writeAll("[");
+            switch (mode) {
+                .vertical => try w.writeAll("[\n"),
+                .horizontal => try w.writeAll("["),
+            }
             try renderArray(indent + 1, mode, node.first_child_id, nodes, code, w);
-            try w.writeAll("]");
-        },
-        .array_comma => {
-            std.debug.assert(node.first_child_id != 0);
-
-            try w.writeAll("[\n");
-            try renderArray(indent + 1, .vertical, node.first_child_id, nodes, code, w);
-            try printIndent(indent, w);
             try w.writeAll("]");
         },
 
@@ -954,8 +1099,8 @@ test "basics" {
 
     var diag: Diagnostic = .{ .path = null };
     errdefer std.debug.print("diag: {}", .{diag});
-    const ast = try Ast.init(std.testing.allocator, case, true, &diag);
-    defer ast.deinit();
+    const ast = try Ast.init(std.testing.allocator, case, true, true, &diag);
+    defer ast.deinit(std.testing.allocator);
     try std.testing.expectFmt(case, "{}", .{ast});
 }
 
@@ -972,8 +1117,8 @@ test "vertical" {
 
     var diag: Diagnostic = .{ .path = null };
     errdefer std.debug.print("diag: {}", .{diag});
-    const ast = try Ast.init(std.testing.allocator, case, true, &diag);
-    defer ast.deinit();
+    const ast = try Ast.init(std.testing.allocator, case, true, true, &diag);
+    defer ast.deinit(std.testing.allocator);
     try std.testing.expectFmt(case, "{}", .{ast});
 }
 
@@ -993,7 +1138,7 @@ test "complex" {
 
     var diag: Diagnostic = .{ .path = null };
     errdefer std.debug.print("diag: {}", .{diag});
-    const ast = try Ast.init(std.testing.allocator, case, true, &diag);
-    defer ast.deinit();
+    const ast = try Ast.init(std.testing.allocator, case, true, true, &diag);
+    defer ast.deinit(std.testing.allocator);
     try std.testing.expectFmt(case, "{}", .{ast});
 }

--- a/src/ziggy/Diagnostic.zig
+++ b/src/ziggy/Diagnostic.zig
@@ -4,56 +4,281 @@ const std = @import("std");
 const Tokenizer = @import("Tokenizer.zig");
 const Token = Tokenizer.Token;
 
-/// The data being parsed, this field should not be set manually by users.
-code: [:0]const u8 = "",
-
 /// A path to the file, used to display diagnostics.
 /// If not present, error positions will be printed as "line: XX col: XX".
 /// This field should be set as needed by users.
 path: ?[]const u8,
 
-tok: Token = .{
-    .tag = .eof,
-    .loc = .{ .start = 0, .end = 0 },
-},
-err: Error = .none,
+/// The data being parsed, this field should not be set manually by users.
+code: [:0]const u8 = "",
+errors: std.ArrayListUnmanaged(Error) = .{},
 
 pub const Error = union(enum) {
-    none,
     overflow,
+    oom,
     eof: struct {
         expected: []const Token.Tag,
     },
     unexpected_token: struct {
+        token: Token,
         expected: []const Token.Tag,
     },
-    invalid_token,
-
+    invalid_token: struct {
+        token: Token,
+    },
     duplicate_field: struct {
-        name: []const u8,
-        first_loc: Token.Loc,
+        token: Token,
+        original: Token.Loc,
     },
-    missing_field: struct {
-        name: []const u8,
+    missing: struct {
+        token: Token,
+        expected: []const u8,
     },
-    unknown_field,
-
+    unknown: struct {
+        token: Token,
+        expected: []const u8,
+    },
     schema: struct {
+        loc: Token.Loc,
         err: anyerror,
     },
-
     type_mismatch: struct {
+        token: Token,
         expected: []const u8,
     },
 
-    missing_struct_name: struct {
-        expected: []const u8,
-    },
+    pub const ZigError = error{ Overflow, OutOfMemory, Syntax };
+    pub fn zigError(e: Error) ZigError {
+        return switch (e) {
+            .overflow => error.Overflow,
+            .oom => error.OutOfMemory,
+            else => error.Syntax,
+        };
+    }
 
-    wrong_struct_name: struct {
-        expected: []const u8,
-    },
+    pub fn getErrorSelection(e: Error, code: [:0]const u8) Token.Loc.Selection {
+        return switch (e) {
+            .overflow, .oom => .{
+                .start = .{ .line = 0, .col = 0 },
+                .end = .{ .line = 0, .col = 0 },
+            },
+            .eof => {
+                const loc: Token.Loc = .{
+                    .start = @intCast(code.len - 1),
+                    .end = @intCast(code.len),
+                };
+                return loc.getSelection(code);
+            },
+            .schema => |s| return s.loc.getSelection(code),
+            inline else => |x| x.token.loc.getSelection(code),
+        };
+    }
+
+    pub fn fmt(e: Error, code: [:0]const u8, path: ?[]const u8) ErrorFmt {
+        return .{
+            .err = e,
+            .code = code,
+            .path = path,
+        };
+    }
+    pub const ErrorFmt = struct {
+        code: [:0]const u8,
+        path: ?[]const u8,
+        err: Error,
+
+        pub fn format(
+            err_fmt: ErrorFmt,
+            comptime fmt_string: []const u8,
+            options: std.fmt.FormatOptions,
+            out_stream: anytype,
+        ) !void {
+            _ = options;
+
+            const lsp = std.mem.eql(u8, fmt_string, "lsp");
+
+            if (!lsp) {
+                const start = err_fmt.err.getErrorSelection(err_fmt.code).start;
+                if (err_fmt.path) |p| {
+                    try out_stream.print("{s}:{}:{}\n", .{
+                        p,
+                        start.line,
+                        start.col,
+                    });
+                } else {
+                    try out_stream.print("line: {} col: {}\n", .{
+                        start.line,
+                        start.col,
+                    });
+                }
+            }
+
+            switch (err_fmt.err) {
+                .oom => try out_stream.print("out of memory\n", .{}),
+                .overflow => {
+                    try out_stream.print("overflow\n", .{});
+                    // if (!lsp) {
+                    //     try out_stream.print(": '{s}'", .{
+                    //         o.token.loc.src(err_fmt.code),
+                    //     });
+                    // }
+                },
+                .invalid_token => |i| {
+                    try out_stream.print("invalid token", .{});
+                    if (!lsp) {
+                        try out_stream.print(": '{s}'", .{
+                            i.token.loc.src(err_fmt.code),
+                        });
+                    }
+                },
+                .eof => |eof| {
+                    if (!lsp) {
+                        try out_stream.print("unexpected EOF, ", .{});
+                    }
+                    try out_stream.print("expected: ", .{});
+
+                    for (eof.expected, 0..) |tag, idx| {
+                        try out_stream.print("'{s}'", .{tag.lexeme()});
+                        if (idx != eof.expected.len - 1) {
+                            try out_stream.print(" or ", .{});
+                        }
+                    }
+
+                    try out_stream.print("\n", .{});
+                },
+                .unexpected_token => |u| {
+                    if (u.token.tag == .eof) {
+                        if (!lsp) {
+                            try out_stream.print("unexpected EOF, ", .{});
+                        }
+                        try out_stream.print("expected: ", .{});
+                    } else {
+                        if (!lsp) {
+                            try out_stream.print("unexpected token: '{s}', ", .{
+                                u.token.loc.src(err_fmt.code),
+                            });
+                        }
+                        try out_stream.print("expected: ", .{});
+                    }
+
+                    for (u.expected, 0..) |tag, idx| {
+                        try out_stream.print("'{s}'", .{tag.lexeme()});
+                        if (idx != u.expected.len - 1) {
+                            try out_stream.print(" or ", .{});
+                        }
+                    }
+
+                    try out_stream.print("\n", .{});
+                },
+                .duplicate_field => |dup| {
+                    if (lsp) {
+                        try out_stream.print("duplicate field", .{});
+                    } else {
+                        const first_sel = dup.original.getSelection(err_fmt.code);
+                        try out_stream.print("found duplicate field '{s}', first definition here:", .{
+                            dup.original.src(err_fmt.code),
+                        });
+                        if (err_fmt.path) |p| {
+                            try out_stream.print("\n{s}:{}:{}\n", .{
+                                p,
+                                first_sel.start.line,
+                                first_sel.start.col,
+                            });
+                        } else {
+                            try out_stream.print(" line: {} col: {}\n", .{
+                                first_sel.start.line,
+                                first_sel.start.col,
+                            });
+                        }
+                    }
+                },
+                .missing => |miss| {
+                    try out_stream.print(
+                        "missing '{s}'",
+                        .{miss.expected},
+                    );
+                },
+                .unknown => |u| {
+                    const name = u.token.loc.src(err_fmt.code);
+                    try out_stream.print(
+                        "unknown '{s}'",
+                        .{name},
+                    );
+                },
+
+                .schema => |s| {
+                    try out_stream.print("schema file error: {s}", .{
+                        @errorName(s.err),
+                    });
+                },
+
+                .type_mismatch => |mism| {
+                    try out_stream.print(
+                        "type mismatch, expected '{s}'",
+                        .{mism.expected},
+                    );
+                },
+
+                // .missing_struct_name => |msn| {
+                //     if (lsp) {
+                //         try out_stream.print(
+                //             "missing struct name, expected one of ({s})",
+                //             .{msn.expected},
+                //         );
+                //     } else {
+                //         const struct_start = msn.token.loc.getSelection(err_fmt.code);
+                //         try out_stream.print(
+                //             "missing struct name, expected '{s}'",
+                //             .{msn.expected},
+                //         );
+                //         if (err_fmt.path) |p| {
+                //             try out_stream.print("\n{s}:{}:{}\n", .{
+                //                 p,
+                //                 struct_start.start.line,
+                //                 struct_start.start.col,
+                //             });
+                //         } else {
+                //             try out_stream.print(" line: {} col: {}\n", .{
+                //                 struct_start.start.line,
+                //                 struct_start.start.col,
+                //             });
+                //         }
+                //     }
+                // },
+
+                // .wrong_struct_name => |wsn| {
+                //     if (lsp) {
+                //         try out_stream.print(
+                //             "wrong struct name, expected one of ({s})",
+                //             .{wsn.expected},
+                //         );
+                //     } else {
+                //         const struct_name = wsn.token.loc.getSelection(err_fmt.code);
+                //         try out_stream.print(
+                //             "wrong struct name '{s}' expected '{s}'",
+                //             .{ wsn.token.loc.src(err_fmt.code), wsn.expected },
+                //         );
+                //         if (err_fmt.path) |p| {
+                //             try out_stream.print("\n{s}:{}:{}\n", .{
+                //                 p,
+                //                 struct_name.start.line,
+                //                 struct_name.start.col,
+                //             });
+                //         } else {
+                //             try out_stream.print(" line: {} col: {}\n", .{
+                //                 struct_name.start.line,
+                //                 struct_name.start.col,
+                //             });
+                //         }
+                //     }
+                // },
+            }
+        }
+    };
 };
+
+pub fn deinit(self: Diagnostic, gpa: std.mem.Allocator) void {
+    self.errors.deinit(gpa);
+}
 
 pub fn debug(self: Diagnostic) void {
     std.debug.print("{}", .{self});
@@ -65,184 +290,7 @@ pub fn format(
     options: std.fmt.FormatOptions,
     out_stream: anytype,
 ) !void {
-    _ = options;
-
-    const lsp = std.mem.eql(u8, fmt, "lsp");
-
-    if (!lsp) {
-        const start = self.tok.loc.getSelection(self.code).start;
-        if (self.path) |p| {
-            try out_stream.print("{s}:{}:{}\n", .{
-                p,
-                start.line,
-                start.col,
-            });
-        } else {
-            try out_stream.print("line: {} col: {}\n", .{
-                start.line,
-                start.col,
-            });
-        }
-    }
-
-    switch (self.err) {
-        .none => {},
-        .overflow => {
-            try out_stream.print("overflow", .{});
-            if (!lsp) {
-                try out_stream.print(": '{s}'", .{
-                    self.tok.loc.src(self.code),
-                });
-            }
-        },
-        .invalid_token => {
-            try out_stream.print("invalid token", .{});
-            if (!lsp) {
-                try out_stream.print(": '{s}'", .{
-                    self.tok.loc.src(self.code),
-                });
-            }
-        },
-        .eof => |eof| {
-            if (!lsp) {
-                try out_stream.print("unexpected EOF, ", .{});
-            }
-            try out_stream.print("expected: ", .{});
-
-            for (eof.expected, 0..) |tag, idx| {
-                try out_stream.print("'{s}'", .{tag.lexeme()});
-                if (idx != eof.expected.len - 1) {
-                    try out_stream.print(" or ", .{});
-                }
-            }
-
-            try out_stream.print("\n", .{});
-        },
-        .unexpected_token => |u| {
-            if (self.tok.tag == .eof) {
-                if (!lsp) {
-                    try out_stream.print("unexpected EOF, ", .{});
-                }
-                try out_stream.print("expected: ", .{});
-            } else {
-                if (!lsp) {
-                    try out_stream.print("unexpected token: '{s}', ", .{
-                        self.tok.loc.src(self.code),
-                    });
-                }
-                try out_stream.print("expected: ", .{});
-            }
-
-            for (u.expected, 0..) |tag, idx| {
-                try out_stream.print("'{s}'", .{tag.lexeme()});
-                if (idx != u.expected.len - 1) {
-                    try out_stream.print(" or ", .{});
-                }
-            }
-
-            try out_stream.print("\n", .{});
-        },
-        .duplicate_field => |dup| {
-            if (lsp) {
-                try out_stream.print("duplicate field", .{});
-            } else {
-                const first_sel = dup.first_loc.getSelection(self.code);
-                try out_stream.print("found duplicate field '{s}', first definition here:", .{
-                    dup.name,
-                });
-                if (self.path) |p| {
-                    try out_stream.print("\n{s}:{}:{}\n", .{
-                        p,
-                        first_sel.start.line,
-                        first_sel.start.col,
-                    });
-                } else {
-                    try out_stream.print(" line: {} col: {}\n", .{
-                        first_sel.start.line,
-                        first_sel.start.col,
-                    });
-                }
-            }
-        },
-        .missing_field => |miss| {
-            try out_stream.print(
-                "missing field '{s}'",
-                .{miss.name},
-            );
-        },
-        .unknown_field => {
-            const name = self.tok.loc.src(self.code);
-            try out_stream.print(
-                "unknown field '{s}'",
-                .{name},
-            );
-        },
-
-        .schema => |s| {
-            try out_stream.print("schema file error: {s}", .{
-                @errorName(s.err),
-            });
-        },
-
-        .type_mismatch => |mism| {
-            try out_stream.print(
-                "type mismatch, expected '{s}'",
-                .{mism.expected},
-            );
-        },
-
-        .missing_struct_name => |msn| {
-            if (lsp) {
-                try out_stream.print(
-                    "missing struct name, expected one of ({s})",
-                    .{msn.expected},
-                );
-            } else {
-                const struct_start = self.tok.loc.getSelection(self.code);
-                try out_stream.print(
-                    "missing struct name, expected '{s}'",
-                    .{msn.expected},
-                );
-                if (self.path) |p| {
-                    try out_stream.print("\n{s}:{}:{}\n", .{
-                        p,
-                        struct_start.start.line,
-                        struct_start.start.col,
-                    });
-                } else {
-                    try out_stream.print(" line: {} col: {}\n", .{
-                        struct_start.start.line,
-                        struct_start.start.col,
-                    });
-                }
-            }
-        },
-
-        .wrong_struct_name => |wsn| {
-            if (lsp) {
-                try out_stream.print(
-                    "wrong struct name, expected one of ({s})",
-                    .{wsn.expected},
-                );
-            } else {
-                const struct_name = self.tok.loc.getSelection(self.code);
-                try out_stream.print(
-                    "wrong struct name '{s}' expected '{s}'",
-                    .{ self.tok.loc.src(self.code), wsn.expected },
-                );
-                if (self.path) |p| {
-                    try out_stream.print("\n{s}:{}:{}\n", .{
-                        p,
-                        struct_name.start.line,
-                        struct_name.start.col,
-                    });
-                } else {
-                    try out_stream.print(" line: {} col: {}\n", .{
-                        struct_name.start.line,
-                        struct_name.start.col,
-                    });
-                }
-            }
-        },
+    for (self.errors.items) |e| {
+        try e.fmt(self.code, self.path).format(fmt, options, out_stream);
     }
 }

--- a/src/ziggy/ResilientParser.zig
+++ b/src/ziggy/ResilientParser.zig
@@ -1,0 +1,657 @@
+const Parser = @This();
+
+gpa: std.mem.Allocator,
+code: [:0]const u8,
+tokenizer: Tokenizer,
+// diagnostic: ?*Diagnostic,
+fuel: u32,
+events: std.ArrayListUnmanaged(Event) = .{},
+filepath: ?[]const u8,
+
+const std = @import("std");
+const mem = std.mem;
+const assert = std.debug.assert;
+const Diagnostic = @import("Diagnostic.zig");
+const Tokenizer = @import("Tokenizer.zig");
+const Token = Tokenizer.Token;
+
+pub const Tree = struct {
+    tag: Tree.Tag,
+    children: std.ArrayListUnmanaged(Child) = .{},
+
+    pub const Tag = enum {
+        err,
+        document,
+        top_level_struct,
+        @"struct",
+        struct_field,
+        array,
+        map,
+        string,
+        line_string,
+        tag_string,
+        integer,
+        float,
+        true,
+        false,
+        null,
+    };
+
+    pub fn deinit(t: *Tree, gpa: mem.Allocator) void {
+        for (t.children.items) |*child| child.deinit(gpa);
+        t.children.deinit(gpa);
+    }
+
+    pub fn fmt(t: Tree, code: [:0]const u8) Fmt {
+        return .{ .code = code, .tree = t };
+    }
+
+    pub const Fmt = struct {
+        code: [:0]const u8,
+        tree: Tree,
+
+        pub fn format(
+            tfmt: Fmt,
+            comptime fmt_str: []const u8,
+            options: std.fmt.FormatOptions,
+            writer: anytype,
+        ) !void {
+            _ = options;
+            if (mem.eql(u8, fmt_str, "pretty"))
+                try tfmt.prettyPrint(writer, 0, false)
+            else
+                try tfmt.dump(writer, 0);
+        }
+
+        fn prettyPrint(tfmt: Fmt, writer: anytype, indent: usize, has_trailing_comma: bool) !void {
+            var i: usize = 0;
+            while (i < tfmt.tree.children.items.len) : (i += 1) {
+                const child = tfmt.tree.children.items[i];
+                switch (child) {
+                    .token => |token| {
+                        switch (token.tag) {
+                            .identifier, .string, .integer, .float => {
+                                try writer.writeAll(token.loc.src(tfmt.code));
+                            },
+                            .comment, .top_comment_line => {
+                                try writer.writeAll(token.loc.src(tfmt.code));
+                                try writer.writeByte('\n');
+                            },
+                            .line_string => {
+                                try writer.writeByte('\n');
+                                try writer.writeByteNTimes(' ', indent * 4);
+                                try writer.writeAll(token.loc.src(tfmt.code));
+                                if (i + 1 == tfmt.tree.children.items.len) {
+                                    try writer.writeByte('\n');
+                                    try writer.writeByteNTimes(' ', indent * 4);
+                                }
+                            },
+                            else => {
+                                const space = mem.indexOfScalar(Token.Tag, &.{.eql}, token.tag) != null;
+                                if (space) try writer.writeByte(' ');
+                                try writer.writeAll(token.tag.lexeme());
+                                if (has_trailing_comma and (token.tag == .lsb or token.tag == .lb or token.tag == .comma)) {
+                                    try writer.writeByte('\n');
+                                    const unindent = token.tag == .comma and
+                                        i + 1 < tfmt.tree.children.items.len and
+                                        tfmt.tree.children.items[i + 1] == .token and
+                                        (tfmt.tree.children.items[i + 1].token.tag == .rsb or
+                                        tfmt.tree.children.items[i + 1].token.tag == .rb);
+                                    const _level = indent -| @as(u8, @intFromBool(unindent));
+                                    try writer.writeByteNTimes(' ', _level * 4);
+                                } else if (tfmt.tree.tag == .top_level_struct) {
+                                    try writer.writeByte('\n');
+                                } else {
+                                    const trailing_space = mem.indexOfScalar(Token.Tag, &.{ .comma, .colon }, token.tag) != null;
+                                    if (space or trailing_space) try writer.writeByte(' ');
+                                }
+                            },
+                        }
+                    },
+                    .tree => |tree| {
+                        const mlast_child = if (tree.children.items.len < 2)
+                            null
+                        else
+                            tree.children.items[tree.children.items.len - 2];
+
+                        const is_container =
+                            tree.tag == .array or
+                            tree.tag == .@"struct" or
+                            tree.tag == .map;
+
+                        const _has_trailing_comma = is_container and
+                            if (mlast_child) |last_child|
+                            last_child == .token and last_child.token.tag == .comma
+                        else
+                            false;
+
+                        const additional_indent = @intFromBool(_has_trailing_comma);
+                        const sub_tfmt = Fmt{ .tree = tree, .code = tfmt.code };
+                        try sub_tfmt.prettyPrint(writer, indent + additional_indent, _has_trailing_comma);
+                    },
+                }
+            }
+        }
+
+        fn dump(tfmt: Fmt, writer: anytype, level: usize) !void {
+            try writer.writeByteNTimes(' ', level * 2);
+            _ = try writer.write(@tagName(tfmt.tree.tag));
+            try writer.writeByte('\n');
+            for (tfmt.tree.children.items) |child| {
+                switch (child) {
+                    .token => |token| {
+                        try writer.writeByteNTimes(' ', level * 2);
+                        try writer.print("  '{s}' {}:{}\n", .{ token.loc.src(tfmt.code), token.loc.start, token.loc.end });
+                    },
+                    .tree => |tree| {
+                        const sub_tfmt = Fmt{ .tree = tree, .code = tfmt.code };
+                        try sub_tfmt.dump(writer, level + 1);
+                    },
+                }
+            }
+        }
+    };
+};
+
+const Child = union(enum) {
+    token: Token,
+    tree: Tree,
+
+    pub fn deinit(c: *Child, gpa: mem.Allocator) void {
+        if (c.* == .tree) c.tree.deinit(gpa);
+    }
+};
+
+const Event = union(enum) {
+    open: Tree.Tag,
+    close,
+    advance,
+};
+
+pub const MarkOpened = enum(usize) {
+    _,
+    pub fn toClosed(m: MarkOpened) MarkClosed {
+        return @enumFromInt(m.toInt());
+    }
+    pub fn toInt(m: MarkOpened) usize {
+        return @intFromEnum(m);
+    }
+};
+
+pub const MarkClosed = enum(usize) {
+    _,
+    pub fn toOpened(m: MarkClosed) MarkOpened {
+        return @enumFromInt(m.toInt());
+    }
+    pub fn toInt(m: MarkClosed) usize {
+        return @intFromEnum(m);
+    }
+};
+
+pub fn parse(
+    gpa: std.mem.Allocator,
+    code: [:0]const u8,
+    // TODO maybe handle diagnostic
+    // diagnostic: ?*Diagnostic,
+    mode: enum { want_comments, no_comments },
+    filepath: ?[]const u8,
+) !Tree {
+    var p = Parser{
+        .gpa = gpa,
+        .code = code,
+        // .diagnostic = diagnostic,
+        .fuel = 256,
+        .filepath = filepath,
+        .tokenizer = .{ .want_comments = mode == .want_comments },
+    };
+    defer p.deinit();
+    p.document();
+    return p.buildTree();
+}
+
+pub fn deinit(p: *Parser) void {
+    p.events.deinit(p.gpa);
+}
+
+/// document = top_comment* (top_level_struct | value)?
+fn document(p: *Parser) void {
+    const m = p.open();
+    while (p.eat(.top_comment_line)) {}
+    while (!p.eof()) {
+        if (p.atAny(&.{ .dot, .comment })) {
+            p.topLevelStruct();
+        } else if (p.atAny(&.{
+            .lb,   .lsb,   .at,   .string, .line_string, .float, .integer,
+            .true, .false, .null,
+        })) {
+            p.value();
+        } else p.advanceWithError("expected a top level struct");
+    }
+    _ = p.close(m, .document);
+}
+
+/// ('//' .?* '\n')*
+fn comments(p: *Parser) void {
+    while (p.eat(.comment)) {}
+}
+
+/// top_level_struct = struct_field (',' struct_field)* ','? comment*
+fn topLevelStruct(p: *Parser) void {
+    const m = p.open();
+    p.structField();
+
+    // note: we must check for eof AFTER eating a comma so that we don't
+    // continue parsing struct fields after a final trailing comma
+    while (p.eat(.comma) and !p.eof()) {
+        p.structField();
+    }
+
+    _ = p.eat(.comma);
+    p.comments();
+    _ = p.close(m, .top_level_struct);
+}
+
+/// struct_field = comment* '.' identifier '=' value
+fn structField(p: *Parser) void {
+    const m = p.open();
+    p.comments();
+    p.expect(.dot);
+    p.expect(.identifier);
+    p.expect(.eql);
+    p.value();
+    _ = p.close(m, .struct_field);
+}
+
+/// value =
+///   struct | map | array | tag_string | string | float
+/// | integer | true | false | null
+fn value(p: *Parser) void {
+    std.log.debug("value {s}", .{@tagName(p.peek(0).tag)});
+    const m = p.open();
+    switch (p.peek(0).tag) {
+        .lb => {
+            switch (p.peek(1).tag) {
+                .dot => {
+                    p.struct_();
+                    _ = p.close(m, .@"struct");
+                },
+                .string => {
+                    p.map();
+                    _ = p.close(m, .map);
+                },
+                else => p.advanceWithErrorNoOpen(m, "expected map or struct"),
+            }
+        },
+        .lsb => {
+            p.array();
+            _ = p.close(m, .array);
+        },
+        .at => {
+            p.tagString();
+            _ = p.close(m, .tag_string);
+        },
+        .string => {
+            p.advance();
+            _ = p.close(m, .string);
+        },
+        .line_string => {
+            p.advance();
+            while (p.eat(.line_string)) {}
+            _ = p.close(m, .line_string);
+        },
+        .integer => {
+            p.advance();
+            _ = p.close(m, .integer);
+        },
+        .float => {
+            p.advance();
+            _ = p.close(m, .float);
+        },
+        .true => {
+            p.advance();
+            _ = p.close(m, .true);
+        },
+        .false => {
+            p.advance();
+            _ = p.close(m, .false);
+        },
+        .null => {
+            p.advance();
+            _ = p.close(m, .null);
+        },
+        else => p.advanceWithErrorNoOpen(m, "expected a value"),
+    }
+}
+
+/// tag_string = '@' identifier '(' string ')'
+fn tagString(p: *Parser) void {
+    const m = p.open();
+    p.expect(.at);
+    p.expect(.identifier);
+    p.expect(.lp);
+    p.expect(.string);
+    p.expect(.rp);
+    _ = p.close(m, .tag_string);
+}
+
+/// array = '[' (array_elem,  (',' array_elem)*)? ','? comment* ']'
+/// array_elem = comment* value
+fn array(p: *Parser) void {
+    // mark open/close is handled in value()
+    p.expect(.lsb);
+
+    while (!p.atAny(&.{ .rsb, .eof })) {
+        p.comments();
+        p.value();
+        if (!p.eat(.comma)) break;
+    }
+
+    _ = p.eat(.comma);
+    p.comments();
+    p.expect(.rsb);
+}
+
+/// struct = struct_name? '{' (struct_field,  (',' struct_field)* )? comment* '}'
+fn struct_(p: *Parser) void {
+    // mark open/close is handled in value()
+    _ = p.eat(.identifier);
+    p.expect(.lb);
+
+    while (!p.atAny(&.{ .rb, .eof })) {
+        p.structField();
+        if (!p.eat(.comma)) break;
+    }
+
+    _ = p.eat(.comma);
+    p.comments();
+    p.expect(.rb);
+}
+
+/// map = '{' (map_field,  (',' map_field)* )? comment* '}'
+/// map_field = comment* string ':' value
+fn map(p: *Parser) void {
+    // mark open/close is handled in value()
+    p.expect(.lb);
+
+    while (!p.atAny(&.{ .rb, .eof })) {
+        p.comments();
+        p.expect(.string);
+        p.expect(.colon);
+        p.value();
+        if (!p.eat(.comma)) break;
+    }
+
+    _ = p.eat(.comma);
+    p.comments();
+    p.expect(.rb);
+}
+
+fn peek(p: *Parser, offset: u32) Token {
+    if (p.fuel == 0) @panic("parser is stuck");
+    p.fuel = p.fuel - 1;
+
+    const idx = p.tokenizer.idx;
+    defer p.tokenizer.idx = idx;
+    var i: u32 = 0;
+    var tok = p.tokenizer.next(p.code);
+    while (i < offset) {
+        i += 1;
+        tok = p.tokenizer.next(p.code);
+    }
+    return tok;
+}
+
+fn eat(p: *Parser, tag: Token.Tag) bool {
+    if (p.at(tag)) {
+        p.advance();
+        return true;
+    }
+    return false;
+}
+
+fn expect(p: *Parser, tag: Token.Tag) void {
+    if (p.eat(tag)) return;
+    p.printError("expected {s}", .{@tagName(tag)});
+}
+
+fn at(p: *Parser, tag: Token.Tag) bool {
+    const tok = p.peek(0);
+    std.log.debug("at({s}) {s}:'{s}'", .{ @tagName(tag), @tagName(tok.tag), tok.loc.src(p.code) });
+    return tag == tok.tag;
+}
+
+fn atAny(p: *Parser, tags: []const Token.Tag) bool {
+    return mem.indexOfScalar(Token.Tag, tags, p.peek(0).tag) != null;
+}
+
+fn printError(p: Parser, comptime fmt: []const u8, args: anytype) void {
+    var pos: u32 = 0;
+    var line: u32 = 1;
+    var col: u32 = 1;
+    var last_nonws_linecol = [2]u32{ line, col };
+    while (pos < p.tokenizer.idx) : (pos += 1) {
+        if (p.code[pos] == '\n') {
+            line += 1;
+            col = 1;
+        } else {
+            col += 1;
+        }
+
+        // TODO decide if simd is overkill here
+        const u8x6 = @Vector(6, u8);
+        const ws: u8x6 = std.ascii.whitespace;
+        const cs: u8x6 = @splat(p.code[pos]);
+        // if (std.mem.indexOfScalar(u8, &std.ascii.whitespace, p.code[pos]) == null) {
+        if (@reduce(.And, cs != ws)) {
+            last_nonws_linecol = .{ line, col };
+        }
+    }
+    if (!@import("builtin").is_test) {
+        // FIXME i'm not sure where to log errors
+        std.debug.print(
+            "{?s}:{}:{}: error: " ++ fmt ++ "\n",
+            .{ p.filepath, last_nonws_linecol[0], last_nonws_linecol[1] } ++ args,
+        );
+    }
+}
+
+fn advanceWithError(p: *Parser, err: []const u8) void {
+    const m = p.open();
+    p.advanceWithErrorNoOpen(m, err);
+}
+
+fn advanceWithErrorNoOpen(p: *Parser, m: MarkOpened, err: []const u8) void {
+    p.printError("{s}", .{err});
+    p.advance();
+    _ = p.close(m, .err);
+}
+
+fn advance(p: *Parser) void {
+    assert(!p.eof());
+    p.fuel = 256;
+    p.events.append(p.gpa, .advance) catch @panic("OOM");
+    _ = p.tokenizer.next(p.code);
+}
+
+fn eof(p: *Parser) bool {
+    return p.peek(0).tag == .eof;
+}
+
+fn open(p: *Parser) MarkOpened {
+    std.log.debug("open", .{});
+    const mark: MarkOpened = @enumFromInt(p.events.items.len);
+    p.events.append(p.gpa, .{ .open = .err }) catch @panic("OOM");
+    return mark;
+}
+
+// fn openBefore(p: *Parser, m: MarkClosed) MarkOpened {
+//     const mark = m.toOpened();
+//     p.events.insert(p.gpa, m.toInt(), .{ .open = .err }) catch @panic("OOM");
+//     return mark;
+// }
+
+fn close(p: *Parser, m: MarkOpened, tag: Tree.Tag) MarkClosed {
+    std.log.debug("close {s}", .{@tagName(tag)});
+    p.events.items[m.toInt()] = .{ .open = tag };
+    p.events.append(p.gpa, .close) catch @panic("OOM");
+    return m.toClosed();
+}
+
+fn buildTree(p: *Parser) !Tree {
+    assert(p.events.pop() == .close);
+    p.tokenizer.idx = 0;
+    var stack = std.ArrayList(Tree).init(p.gpa);
+    defer stack.deinit();
+    for (p.events.items) |event| {
+        // std.log.debug("build_tree() event={}", .{event});
+        switch (event) {
+            .open => |tag| try stack.append(.{ .tag = tag }),
+            .close => {
+                const tree = stack.pop();
+                try stack.items[stack.items.len - 1].children.append(
+                    p.gpa,
+                    .{ .tree = tree },
+                );
+            },
+            .advance => {
+                try stack.items[stack.items.len - 1].children.append(
+                    p.gpa,
+                    .{ .token = p.tokenizer.next(p.code) },
+                );
+            },
+        }
+    }
+
+    const tree = stack.pop();
+    assert(stack.items.len == 0);
+    assert(p.tokenizer.next(p.code).tag == .eof);
+    return tree;
+}
+
+test "basics" {
+    const case =
+        \\.foo = "bar",
+        \\.bar = [1, 2, 3],
+        \\
+    ;
+
+    var tree = try parse(std.testing.allocator, case, .want_comments, null);
+    defer tree.deinit(std.testing.allocator);
+    try std.testing.expectFmt(case, "{pretty}", .{tree.fmt(case)});
+}
+
+test "vertical" {
+    const case =
+        \\.foo = "bar",
+        \\.bar = [
+        \\    1,
+        \\    2,
+        \\    3,
+        \\],
+        \\
+    ;
+
+    var tree = try parse(std.testing.allocator, case, .want_comments, null);
+    defer tree.deinit(std.testing.allocator);
+    try std.testing.expectFmt(case, "{pretty}", .{tree.fmt(case)});
+}
+
+test "complex" {
+    const case =
+        \\.foo = "bar",
+        \\.bar = [
+        \\    1,
+        \\    23.45,
+        \\    {
+        \\        "abc": "foo",
+        \\        "baz": ["foo", "bar"],
+        \\    },
+        \\],
+        \\.t = true,
+        \\.f = false,
+        \\.n = null,
+        \\.date = @date("2020-10-01T00:00:00"),
+        \\
+    ;
+
+    var tree = try parse(std.testing.allocator, case, .want_comments, null);
+    defer tree.deinit(std.testing.allocator);
+    try std.testing.expectFmt(case, "{pretty}", .{tree.fmt(case)});
+}
+
+test "comments" {
+    const case =
+        \\//! top comment
+        \\//! top comment2
+        \\// foo field comment
+        \\// foo field comment2
+        \\.foo = "bar",
+        \\// bar field comment
+        \\// bar field comment2
+        \\.bar = null
+    ;
+
+    var tree = try parse(std.testing.allocator, case, .want_comments, null);
+    defer tree.deinit(std.testing.allocator);
+    try std.testing.expectFmt(case, "{pretty}", .{tree.fmt(case)});
+}
+
+test "top level non-struct values" {
+    const testCase = struct {
+        fn func(case: [:0]const u8) !void {
+            var tree = try parse(std.testing.allocator, case, .want_comments, null);
+            defer tree.deinit(std.testing.allocator);
+            try std.testing.expectFmt(case, "{pretty}", .{tree.fmt(case)});
+        }
+    }.func;
+    try testCase("true");
+    try testCase("false");
+    try testCase("null");
+    try testCase(
+        \\"top str"
+    );
+    try testCase("123");
+    try testCase("123.45");
+    try testCase("{.a = 1, .b = 2}");
+    try testCase(
+        \\{"a": 1, "b": 2}
+    );
+    try testCase(
+        \\[true, false, null, "str", 123, {.a = 1, .b = 2}, {"a": 1, "b": 2}]
+    );
+}
+
+test "misc" {
+    const testCase = struct {
+        fn func(case: [:0]const u8) !void {
+            var tree = try parse(std.testing.allocator, case, .want_comments, null);
+            defer tree.deinit(std.testing.allocator);
+            try std.testing.expectFmt(case, "{pretty}", .{tree.fmt(case)});
+        }
+    }.func;
+    try testCase("[]");
+    // FIXME: re-enable this test case which panics @Tokenizer.zig:190:55
+    // try testCase("");
+    try testCase("{}");
+}
+
+test "line string" {
+    const case =
+        \\{
+        \\    "extended_description": 
+        \\    \\Lorem ipsum dolor something something,
+        \\    \\this is a multiline string literal.
+        \\    ,
+        \\}
+    ;
+    var tree = try parse(std.testing.allocator, case, .want_comments, null);
+    defer tree.deinit(std.testing.allocator);
+    try std.testing.expectFmt(case, "{pretty}", .{tree.fmt(case)});
+}
+
+test "invalid" {
+    const case = ".a = , ";
+    var tree = try parse(std.testing.allocator, case, .want_comments, null);
+    defer tree.deinit(std.testing.allocator);
+    try std.testing.expectFmt(case, "{pretty}", .{tree.fmt(case)});
+}

--- a/src/ziggy/Tokenizer.zig
+++ b/src/ziggy/Tokenizer.zig
@@ -171,6 +171,13 @@ const State = enum {
     comment,
 };
 
+pub fn peek(self: *Tokenizer, code: [:0]const u8) Token {
+    const idx = self.idx;
+    const t = self.next(code);
+    self.idx = idx;
+    return t;
+}
+
 pub fn next(self: *Tokenizer, code: [:0]const u8) Token {
     var state: State = .start;
     var res: Token = .{


### PR DESCRIPTION
* passes all the pretty printing tests from ziggy/Ast.zig
* format specifiers:
  * {pretty} calls prettyPrint()
  * {} calls dump().  i've found this very useful for Tree visualisation.
* added new tests: "comments", "top level non-struct values", "line string", "misc", "invalid"
* TODO
  * provide the previous, uniform Ast.init() api which i think is used elsewhere
  	* decide how to handle diagnostics
  * add more formatting options like indentation
  * decide how to log errors
  * decide what to do about empty string input panic @Tokenizer.zig:190:55