### PR TITLE
prevent tokenizer oob on unterminated string

### DIFF
--- a/src/ziggy/ResilientParser.zig
+++ b/src/ziggy/ResilientParser.zig
@@ -15,7 +15,6 @@ const Diagnostic = @import("Diagnostic.zig");
 const Tokenizer = @import("Tokenizer.zig");
 const Token = Tokenizer.Token;
 const Rule = ziggy.schema.Schema.Rule;
-
 const log = std.log.scoped(.resilient_parser);
 
 pub const Tree = struct {
@@ -1092,6 +1091,11 @@ test "invalid" {
     // about the lost whitespace. what should be rendered there?
     try expectFmt(".a = 1 .b = 2", ".a = 1.b = 2");
     try expectFmt(".a = ; ", ".a = (invalid)");
+    try expectFmt(
+        \\["a "b"] 
+    ,
+        \\["a "b (invalid)
+    );
 }
 
 test "nested named structs" {


### PR DESCRIPTION
previously when given the input '["a "b"]', the tokenizer would go oob. i prevented this by changing Tokenizer.next()'s main loop from while(true) to while(tokenizer.idx < code.len).  and this required some other changes to get all the tests passing again.

i added a few more Tokenizer tests and a testCase() helper too.