### PR TITLE
ResilientParser rework

### DIFF
--- a/src/cli/lsp/Document.zig
+++ b/src/cli/lsp/Document.zig
@@ -9,7 +9,7 @@ const log = std.log.scoped(.lsp_document);
 arena: std.heap.ArenaAllocator,
 bytes: [:0]const u8,
 diagnostic: ziggy.Diagnostic,
-ast: ?ziggy.LanguageServerAst = null,
+ast: ?if (ziggy.lsp_parser == .recover) ziggy.LanguageServerAst else ziggy.LanguageServerAst.Tree = null,
 schema_path_loc: ?ziggy.Tokenizer.Token.Loc = null,
 schema: ?LoadedSchema = null,
 

--- a/src/ziggy/RecoverAst.zig
+++ b/src/ziggy/RecoverAst.zig
@@ -57,7 +57,7 @@ code: [:0]const u8,
 nodes: []const Node,
 suggestions: []const Suggestion = &.{},
 
-const Suggestion = struct {
+pub const Suggestion = struct {
     loc: Token.Loc,
     completions: []const Completion = &.{},
 


### PR DESCRIPTION
* many more recovery paths have been added.  it is now rare to see squiggles to the end of the document.  the parser usually is able to recover and parse remaining fields and values.
* use new diagnostics API
* initial WIP completions support. completions work if you type '.t', showing completions for 'tags', and 'title' fields.  however they don't work if you type '.' alone. and this is a major TODO which i'm not sure how to address yet.  i've added some FIXME and TODO comments for this and welcome any ideas.