### PR TITLE
feat: add Nix flake to build Ziggy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .zig-cache/
 zig-out/
 release/
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,58 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1719994518,
+        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1721924956,
+        "narHash": "sha256-Sb1jlyRO+N8jBXEX9Pg9Z1Qb8Bw9QyOgLDNMEpmjZ2M=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5ad6a14c6bf098e98800b091668718c336effc95",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1719876945,
+        "narHash": "sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+  description = "Description for the project";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-parts = {
+        url = "github:hercules-ci/flake-parts";
+    };
+  };
+
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
+      perSystem = { config, self', inputs', pkgs, system, ... }:
+      {
+        packages.default = pkgs.stdenv.mkDerivation {
+            name = "ziggy";
+            version = "0.0.0";
+            src = ./.;
+            nativeBuildInputs = [ pkgs.zig.hook ];
+        };
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -11,13 +11,16 @@
   outputs = inputs@{ flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
       systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
-      perSystem = { config, self', inputs', pkgs, system, ... }:
-      {
+      perSystem = { pkgs, ... }:
+      rec {
         packages.default = pkgs.stdenv.mkDerivation {
             name = "ziggy";
             version = "0.0.0";
             src = ./.;
             nativeBuildInputs = [ pkgs.zig.hook ];
+        };
+        devShells.default = pkgs.mkShell {
+            buildInputs = [ packages.default.nativeBuildInputs ];
         };
       };
     };


### PR DESCRIPTION
This is for handling a Nix build of Ziggy using the [Nix Zig hook](https://github.com/NixOS/nixpkgs/blob/master/doc/hooks/zig.section.md). This is a simple way to get up and running with using Zig to build the project but it is not as expansive as something like [zls' flake](https://github.com/zigtools/zls/blob/45eb38e2365c3f9fe7cee5a37a0f8d5c8645f888/flake.nix). We also add a devshell to enable access to the nixpkgs zig toolchain for debugging.