### PR TITLE
fix: Multiline string typematched as bytes

### DIFF
--- a/src/ziggy/Ast.zig
+++ b/src/ziggy/Ast.zig
@@ -756,7 +756,7 @@ pub fn check(
                 else => try doc.typeMismatch(gpa, diag, rules, elem),
             },
             .bytes => switch (doc_node.tag) {
-                .string, .line_string => {},
+                .string, .line_string, .multiline_string => {},
                 else => try doc.typeMismatch(gpa, diag, rules, elem),
             },
             .int => switch (doc_node.tag) {

--- a/src/ziggy/Parser.zig
+++ b/src/ziggy/Parser.zig
@@ -845,3 +845,23 @@ test "unions" {
     try std.testing.expect(c.dep2 == .Local);
     try std.testing.expectEqualStrings("../super", c.dep2.Local.path);
 }
+
+test "multiline string" {
+    const just_str =
+        \\.outer = Stri {
+        \\  .str =
+        \\    \\fst
+        \\    \\snd
+        \\  ,
+        \\}
+    ;
+
+    const MultiStr = struct {
+        outer: struct {
+            str: []const u8,
+        }
+    };
+
+    const c = try parseLeaky(MultiStr, std.testing.allocator, just_str, .{});
+    try std.testing.expectEqualStrings("fst\nsnd", c.outer.str);
+}

--- a/src/ziggy/Tokenizer.zig
+++ b/src/ziggy/Tokenizer.zig
@@ -475,3 +475,12 @@ test "want comments + trailing" {
         \\// comment
     , &.{ .comment, .eof }, true);
 }
+
+test "multiline string" {
+    try testCase(
+        \\.str =
+        \\  \\fst
+        \\  \\snd
+        \\,
+    , &.{ .dot, .identifier, .eql, .line_string, .line_string, .comma, .eof }, true);
+}


### PR DESCRIPTION
Makes schema checks correctly interpret multiline string as of the 'bytes' type.

Also, adds simple unittests for multiline string for Parser and Tokenizer.