### PR TITLE
Ensure ziggy fmt writes single newline at end of file

### DIFF
--- a/src/cli/fmt.zig
+++ b/src/cli/fmt.zig
@@ -196,7 +196,7 @@ pub fn fmtZiggy(
         std.process.exit(1);
     };
 
-    return std.fmt.allocPrint(gpa, "{}", .{doc});
+    return std.fmt.allocPrint(gpa, "{}\n", .{doc});
 }
 
 fn fmtSchema(


### PR DESCRIPTION
Fixes #51

Approach taken:
- The format result of an `Ast` object (via `ziggy.Ast.render()`) never ends in a newline
  - Consistent/symmetrical handling in `renderValue()`: the handling for horizontal vs. vertical is now done in the same place for opening and closing of brackets
  - No trailing newline written by `renderArray()` and `renderFields()`, this is the responsibility of the calling function if needed (not needed in the case of braceless structs)
- The code associated with a `ziggy fmt` command (`cli.fmt.fmtZiggy()`) adds the trailing newline
- Added unit tests in `src/ziggy/Ast.zig`

Also tested `ziggy fmt` manually.

Note: the formatting code is duplicated in `src/ziggy/RecoverAst.zig`, but this doesn't seem to be used for actually writing out files so I haven't bothered to update it; ideally the logic would be commonised/shared.