### PR TITLE
convert: proper ziggy output formatting

### DIFF
--- a/src/cli/convert.zig
+++ b/src/cli/convert.zig
@@ -192,7 +192,7 @@ fn convertFromZiggy(
     bytes: [:0]const u8,
 ) ![]const u8 {
     var diag: ziggy.Diagnostic = .{ .path = file_path };
-    const doc = Ast.init(gpa, bytes, true, false, &diag) catch {
+    const doc = Ast.init(gpa, bytes, true, false, false, &diag) catch {
         if (diag.errors.items.len != 0) {
             std.debug.print("{}\n", .{diag});
         }
@@ -202,7 +202,7 @@ fn convertFromZiggy(
 
     return switch (format) {
         else => @panic("TODO: support more file formats https://github.com/kristoff-it/ziggy/issues/17"),
-        .json => "",
+        .json => @panic("TODO: support converting from ziggy"),
     };
 }
 
@@ -222,7 +222,7 @@ fn convertToZiggy(
             std.process.exit(1);
         },
     };
-    return std.fmt.allocPrint(gpa, "{}", .{doc});
+    return std.fmt.allocPrint(gpa, "{}\n", .{doc});
 }
 
 fn fatalDiag(diag: anytype) noreturn {

--- a/src/cli/convert.zig
+++ b/src/cli/convert.zig
@@ -14,13 +14,8 @@ pub fn run(gpa: std.mem.Allocator, args: []const []const u8) !void {
         .stdin => |lang| {
             const r = std.io.getStdIn().reader();
             const w = std.io.getStdOut().writer();
-            switch (lang) {
-                .json => {
-                    const bytes = try convertToZiggy(gpa, .json, null, schema, r);
-                    try w.writeAll(bytes);
-                },
-                else => @panic("TODO https://github.com/kristoff-it/ziggy/issues/17"),
-            }
+            const bytes = try convertReader(gpa, lang, cmd.to, null, schema, r);
+            try w.writeAll(bytes);
         },
         .paths => |paths| {
             // checkFile will reset the arena at the end of each call
@@ -115,8 +110,8 @@ fn convertDir(
 
 fn convertFile(
     arena_impl: *std.heap.ArenaAllocator,
-    format: Command.Lang,
-    to: Command.Lang,
+    from_format: Command.Lang,
+    to_format: Command.Lang,
     force: bool,
     base_dir: std.fs.Dir,
     sub_path: []const u8,
@@ -133,16 +128,14 @@ fn convertFile(
     if (stat.kind == .directory)
         return error.IsDir;
 
-    const bytes = switch (to) {
-        .ziggy => try convertToZiggy(
-            arena,
-            format,
-            full_path,
-            schema,
-            in.reader(),
-        ),
-        else => @panic("TODO"),
-    };
+    const bytes = try convertReader(
+        arena,
+        from_format,
+        to_format,
+        full_path,
+        schema,
+        in.reader(),
+    );
 
     // if the file has an expected file extension, we remove it before appending
     // the new extension
@@ -160,7 +153,7 @@ fn convertFile(
 
     const out_path = try std.fmt.allocPrint(arena, "{s}.{s}", .{
         extensionless,
-        @tagName(to),
+        @tagName(to_format),
     });
 
     const out = base_dir.createFile(out_path, .{ .exclusive = !force }) catch |err| {
@@ -174,28 +167,62 @@ fn convertFile(
     try out.writeAll(bytes);
 }
 
+fn convertReader(
+    gpa: std.mem.Allocator,
+    from_format: Command.Lang,
+    to_format: Command.Lang,
+    file_path: ?[]const u8,
+    schema: ziggy.schema.Schema,
+    reader: std.fs.File.Reader,
+) ![]const u8 {
+    var buf = std.ArrayList(u8).init(gpa);
+    defer buf.deinit();
+    try reader.readAllArrayList(&buf, ziggy.max_size);
+    const bytes = try buf.toOwnedSliceSentinel(0);
+    return switch (from_format) {
+        .ziggy => try convertFromZiggy(gpa, to_format, file_path, bytes),
+        else => try convertToZiggy(gpa, from_format, file_path, schema, bytes),
+    };
+}
+
+fn convertFromZiggy(
+    gpa: std.mem.Allocator,
+    format: Command.Lang,
+    file_path: ?[]const u8,
+    bytes: [:0]const u8,
+) ![]const u8 {
+    var diag: ziggy.Diagnostic = .{ .path = file_path };
+    const doc = Ast.init(gpa, bytes, true, false, &diag) catch {
+        if (diag.errors.items.len != 0) {
+            std.debug.print("{}\n", .{diag});
+        }
+        std.process.exit(1);
+    };
+    _ = doc;
+
+    return switch (format) {
+        else => @panic("TODO: support more file formats https://github.com/kristoff-it/ziggy/issues/17"),
+        .json => "",
+    };
+}
+
 fn convertToZiggy(
     gpa: std.mem.Allocator,
     format: Command.Lang,
     file_path: ?[]const u8,
     schema: ziggy.schema.Schema,
-    r: std.fs.File.Reader,
+    bytes: [:0]const u8,
 ) ![]const u8 {
     var diag: ziggy.Diagnostic = .{ .path = file_path };
 
-    switch (format) {
-        else => {
-            @panic("TODO: support more file formats");
+    const doc = switch (format) {
+        else => @panic("TODO: support more file formats https://github.com/kristoff-it/ziggy/issues/17"),
+        .json => json.toZiggy(gpa, schema, &diag, bytes) catch {
+            std.debug.print("{} arstasr\n", .{diag});
+            std.process.exit(1);
         },
-        .json => {
-            const bytes = json.toZiggy(gpa, schema, &diag, r) catch {
-                std.debug.print("{} arstasr\n", .{diag});
-                std.process.exit(1);
-            };
-
-            return bytes;
-        },
-    }
+    };
+    return std.fmt.allocPrint(gpa, "{}", .{doc});
 }
 
 fn fatalDiag(diag: anytype) noreturn {

--- a/src/cli/convert/json.zig
+++ b/src/cli/convert/json.zig
@@ -12,9 +12,9 @@ pub fn toZiggy(
     diag: ?*ziggy.Diagnostic,
     bytes: [:0]const u8,
 ) !Ast {
-    var js_diag: std.json.Diagnostics = .{};
+    var json_diag: std.json.Diagnostics = .{};
     var scanner = std.json.Scanner.initCompleteInput(gpa, bytes);
-    scanner.enableDiagnostics(&js_diag);
+    scanner.enableDiagnostics(&json_diag);
 
     var out = std.ArrayList(u8).init(gpa);
     errdefer out.deinit();
@@ -23,7 +23,7 @@ pub fn toZiggy(
         .gpa = gpa,
         .code = bytes,
         .tokenizer = &scanner,
-        .json_diag = &js_diag,
+        .json_diag = &json_diag,
         .diagnostic = diag,
         .schema = schema,
         .out = out.writer(),
@@ -33,8 +33,8 @@ pub fn toZiggy(
 
     // TODO: Rewrite to directly construct AST rather than writing bytes to an
     //       ArrayList(u8).
-    const ziggy_bytes = try out.toOwnedSlice();
-    return try Ast.init(gpa, ziggy_bytes, true, true, &diag);
+    const ziggy_bytes = try out.toOwnedSliceSentinel(0);
+    return try Ast.init(gpa, ziggy_bytes, true, true, false, diag);
 }
 
 const Converter = struct {

--- a/src/cli/convert/json.zig
+++ b/src/cli/convert/json.zig
@@ -32,7 +32,7 @@ pub fn toZiggy(
     try c.convertJsonValue(try c.next(), schema.root);
 
     // TODO: Rewrite to directly construct AST rather than writing bytes to an
-    //       ArrayList(u8).
+    //       ArrayList(u8), https://github.com/kristoff-it/ziggy/issues/52.
     const ziggy_bytes = try out.toOwnedSliceSentinel(0);
     return try Ast.init(gpa, ziggy_bytes, true, true, false, diag);
 }


### PR DESCRIPTION
The `ziggy convert` command currently gives unformatted output, which is because the ziggy output is constructed manually rather than going via an AST (see https://github.com/kristoff-it/ziggy/issues/52). This is a short-term fix that creates an AST from the manually constructed ziggy, which serves to validate the constructed output and provide formatting guaranteed to match `ziggy fmt`.

Using this example json file:
```
$cat example3.json
[
  {
    "name": "Katheryn McDaniel",
    "address": "138 Almond Street, Topeka, Kansas 20697",
    "email": "KateMcD@aol.com",
    "additional-roles": [ "board member" ]
  }
]
```
Previous output:
```
$ziggy convert --stdin json < example3.json
[{"name":"Katheryn McDaniel","address":"138 Almond Street, Topeka, Kansas 20697","email":"KateMcD@aol.com","additional-roles":["board member",],},]
```
New output:
```
$zig build run -- convert --stdin json < example3.json
[
    {
        "name": "Katheryn McDaniel",
        "address": "138 Almond Street, Topeka, Kansas 20697",
        "email": "KateMcD@aol.com",
        "additional-roles": [
            "board member",
        ],
    },
]
```