### PR TITLE
feat: add release packaging & automated GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-release:
+    name: Build and Release
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v1
+        with:
+          version: master
+
+      - name: Install zip
+        run: sudo apt-get update && sudo apt-get install -y zip
+
+      - name: Build release artifacts
+        run: zig build release
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: zig-out/archives/*
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,8 @@ on:
       - 'v*'
 
 jobs:
-  build-and-release:
-    name: Build and Release
+  release:
+    name: Release ziggy
     runs-on: ubuntu-latest
     
     steps:
@@ -18,9 +18,6 @@ jobs:
         uses: mlugg/setup-zig@v1
         with:
           version: master
-
-      - name: Install zip
-        run: sudo apt-get update && sudo apt-get install -y zip
 
       - name: Build release artifacts
         run: zig build release


### PR DESCRIPTION
Hey @kristoff-it, this PR adds cross-platform binary packaging and an automated release workflow to streamline the release process for Ziggy. I was looking at https://github.com/kristoff-it/ziggy/issues/48 and figured out that there was no real release mechanism. I don't know if there is anything on the roadmap for that, tried to keep it as minimal as possible.

## Changes
- **Build system improvements:**
  - Added `tar.gz` packaging for Unix-like platforms (macOS, Linux)
  - Added `zip` packaging for Windows platforms
  - All packages are organized in `zig-out/archives/` 

- **CI/CD improvements:**
  - Added GitHub Actions workflow for automated releases
  - Releases are triggered when a tag starting with "v" is pushed
  - All binary packages are automatically attached to GitHub releases
  - Release notes are automatically generated from commit history

## How to use
To create a new release:
1. Ensure all changes are committed and pushed to main
2. Create and push a tag: `git tag v1.0.0 && git push origin v1.0.0`
3. The workflow will automatically build all packages and create a GitHub release

## Motivation
This addresses the issue with Zed extension SDK not supporting xz decompression by providing gzip and zip alternatives. https://github.com/kristoff-it/ziggy/issues/48

