### PR TITLE
Add trailing LF to help commands, and fix "exit" typo in fmt's help message

### DIFF
--- a/src/cli/check.zig
+++ b/src/cli/check.zig
@@ -157,6 +157,8 @@ pub const Command = struct {
             \\Options:
             \\
             \\--help, -h       Print this help and exit.
+            \\
+            \\
         , .{});
 
         std.process.exit(1);

--- a/src/cli/convert.zig
+++ b/src/cli/convert.zig
@@ -513,6 +513,8 @@ pub const Command = struct {
             \\                 immediately.
             \\
             \\--help, -h       Print this help and exit.
+            \\
+            \\
         , .{});
 
         std.process.exit(1);

--- a/src/cli/fmt.zig
+++ b/src/cli/fmt.zig
@@ -349,6 +349,8 @@ pub const Command = struct {
             \\                   error if the list is not empty.
             \\
             \\--help, -h         Prints this help and extits.
+            \\
+            \\
         , .{});
 
         std.process.exit(1);

--- a/src/cli/fmt.zig
+++ b/src/cli/fmt.zig
@@ -348,7 +348,7 @@ pub const Command = struct {
             \\--check            List non-conforming files and exit with an
             \\                   error if the list is not empty.
             \\
-            \\--help, -h         Prints this help and extits.
+            \\--help, -h         Prints this help and exits.
             \\
             \\
         , .{});


### PR DESCRIPTION
The diff and title describes everything.
