### PR TITLE
fix: memory leak on error in `deserialize`

### DIFF
--- a/src/Deserializer.zig
+++ b/src/Deserializer.zig
@@ -284,6 +284,8 @@ pub fn deserialize(
 ) Deserializer.Error!Value(T) {
     var result: Value(T) = undefined;
     result.arena_state = .init(gpa);
+    errdefer result.deinit();
+
     result.value = try deserializeLeaky(T, result.arena_state.allocator(), src, meta, opts);
     return result;
 }


### PR DESCRIPTION
`ziggy.deserialize()` doesnt deinit arena allocator if `deserializeLeaky` returns an error.