### PR TITLE
Update to Zig 0.17.0-dev.607+456b2ec07

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@ jobs:
 
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
+        with:
+          version: master
 
       - name: Build
-        run: zig build test 
-          
+        run: zig build test

--- a/build.zig
+++ b/build.zig
@@ -62,7 +62,8 @@ pub fn build(b: *std.Build) !void {
     b.installArtifact(cli_exe);
 
     const run_exe = b.addRunArtifact(cli_exe);
-    if (b.args) |args| run_exe.addArgs(args);
+    run_exe.addPassthruArgs();
+
     const run_exe_step = b.step("run", "Run the Ziggy tool");
     run_exe_step.dependOn(&run_exe.step);
 
@@ -276,14 +277,14 @@ pub fn setupTests(
     cli_exe: *std.Build.Step.Compile,
 ) !void {
     const test_step = b.step("test", "Run unit & snapshot tests");
+    const filters = b.option([]const []const u8, "filters", "unit test filters");
 
     const unit_tests = b.addTest(.{
         .root_module = ziggy_module,
-        .filters = b.args orelse &.{},
+        .filters = filters orelse &.{},
     });
 
     const run_unit_tests = b.addRunArtifact(unit_tests);
-    // if (b.args) |args| run_unit_tests.addArgs(args);
     test_step.dependOn(&run_unit_tests.step);
 
     if (true) return;
@@ -420,14 +421,14 @@ const Version = union(Kind) {
     }
 };
 fn getGitVersion(b: *std.Build) Version {
-    const git_path = b.findProgram(&.{"git"}, &.{}) catch return .unknown;
+    const git_path = b.findProgram(.{ .names = &.{"git"} }) orelse return .unknown;
     var out: u8 = undefined;
     const git_describe = std.mem.trim(
         u8,
         b.runAllowFail(&[_][]const u8{
-            git_path,            "-C",
-            b.build_root.path.?, "describe",
-            "--match",           "*.*.*",
+            git_path,               "-C",
+            b.root.root_dir.path.?, "describe",
+            "--match",              "*.*.*",
             "--tags",
         }, &out, .ignore) catch return .unknown,
         " \n\r",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,17 +5,13 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .known_folders = .{
-            .url = "git+https://github.com/ziglibs/known-folders#175f5596b3d2ee3c658282bb07885580895a0e73",
-            .hash = "known_folders-0.0.0-Fy-PJk7KAAC41mQXzmFyGa0Q7tvmQjatENkREa6Gc4zu",
+            .url = "git+https://github.com/ziglibs/known-folders#207c34a16e4365edc20d92c7892f962b3bed46e8",
+            .hash = "known_folders-0.0.0-Fy-PJsbKAACbDh9bBxR0MMThxZSS6A9RH4apWphNHY70",
         },
         .lsp_kit = .{
             .url = "git+https://github.com/zigtools/lsp-kit#ec325a3c33d1da7708cf513355208f74d9560580",
             .hash = "lsp_kit-0.1.0-bi_PL_kyDACVTEhLaMq2-PJx0MocqRyjXDAN0ybMUyQQ",
         },
-        // .yaml = .{
-        //     .url = "git+https://github.com/dotcarmen/zig-yaml.git?ref=0.16-io-interface#695e62bb080028fdd0b33145a1dd6d1d7879ac42",
-        //     .hash = "zig_yaml-0.2.0-C1161jirAgAUjfuDVZPH4SvzvXYu0FlvakDifJzAsEF2",
-        // },
     },
     .paths = .{
         "build.zig",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .ziggy,
     .version = "0.1.0",
     .fingerprint = 0x7d935ea7bf3c3891,
-    .minimum_zig_version = "0.16.0",
+    .minimum_zig_version = "0.17.0-dev.607+456b2ec07",
     .dependencies = .{
         .known_folders = .{
             .url = "git+https://github.com/ziglibs/known-folders#207c34a16e4365edc20d92c7892f962b3bed46e8",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -9,8 +9,8 @@
             .hash = "known_folders-0.0.0-Fy-PJsbKAACbDh9bBxR0MMThxZSS6A9RH4apWphNHY70",
         },
         .lsp_kit = .{
-            .url = "git+https://github.com/zigtools/lsp-kit#ec325a3c33d1da7708cf513355208f74d9560580",
-            .hash = "lsp_kit-0.1.0-bi_PL_kyDACVTEhLaMq2-PJx0MocqRyjXDAN0ybMUyQQ",
+            .url = "git+https://github.com/zigtools/lsp-kit#9a25d49e6bafad3aaaa5d26dbf854973b2b31cfe",
+            .hash = "lsp_kit-0.1.0-bi_PLzQzDABHZKMkjtOV7Ipr7TH_LPuC3U42tWmaPGem",
         },
     },
     .paths = .{

--- a/src/Deserializer.zig
+++ b/src/Deserializer.zig
@@ -447,7 +447,7 @@ pub fn deserializeOne(d: *const Deserializer, T: type, first: Token, top_lvl: bo
                 return T.ziggy_options.deserialize(d, first, top_lvl);
             }
 
-            var seen: std.StaticBitSet(info.fields.len) = .initEmpty();
+            var seen: std.StaticBitSet(info.fields.len) = .empty;
             var result: T = undefined;
 
             var field_token = if (top_lvl and first.tag == .identifier)

--- a/src/cli/logging.zig
+++ b/src/cli/logging.zig
@@ -34,7 +34,7 @@ pub fn setup(io: Io, gpa: Allocator, environ_map: std.process.Environ.Map) void 
 
 fn setupInternal(io: Io, gpa: Allocator, environ_map: std.process.Environ.Map) !void {
     const log_name = "ziggy.log";
-    var cache_base = try folders.open(io, gpa, environ_map, .cache, .{}) orelse return error.Failure;
+    var cache_base = try folders.open(io, gpa, &environ_map, .cache, .{}) orelse return error.Failure;
     defer cache_base.close(io);
 
     const f: Io.File = try cache_base.createFile(io, log_name, .{ .truncate = false });

--- a/src/cli/lsp.zig
+++ b/src/cli/lsp.zig
@@ -128,7 +128,7 @@ pub fn @"textDocument/didOpen"(
     arena: std.mem.Allocator,
     notification: types.TextDocument.DidOpenParams,
 ) !void {
-    const new_text = try self.gpa.dupeZ(u8, notification.textDocument.text); // We informed the client that we only do full document syncs
+    const new_text = try self.gpa.dupeSentinel(u8, notification.textDocument.text, 0); // We informed the client that we only do full document syncs
     errdefer self.gpa.free(new_text);
 
     std.log.debug("didopen! {t} {s}", .{
@@ -170,9 +170,10 @@ pub fn @"textDocument/didChange"(
     notification: types.TextDocument.DidChangeParams,
 ) !void {
     if (notification.contentChanges.len == 0) return;
-    const new_text = try self.gpa.dupeZ(
+    const new_text = try self.gpa.dupeSentinel(
         u8,
         notification.contentChanges[notification.contentChanges.len - 1].text_document_content_change_whole_document.text,
+        0,
     ); // We informed the client that we only do full document syncs
     errdefer self.gpa.free(new_text);
 

--- a/src/schema/Ast.zig
+++ b/src/schema/Ast.zig
@@ -1947,7 +1947,8 @@ pub fn validate(
                                     .opt_identifier => container_name[1..], // skip '?'
                                     else => unreachable,
                                 };
-                                var current_scope = scope;
+
+                                var current_scope = scope.?;
                                 const container_idx = while (true) {
                                     break schema_ast.scopes.get(current_scope).?.types.get(
                                         search_name,
@@ -2024,7 +2025,8 @@ pub fn validate(
                                     .opt_identifier => container_name[1..], // skip '?'
                                     else => unreachable,
                                 };
-                                var current_scope = scope;
+
+                                var current_scope = scope.?;
                                 const container_idx = while (true) {
                                     break schema_ast.scopes.get(current_scope).?.types.get(
                                         search_name,
@@ -2146,7 +2148,7 @@ pub fn validate(
                                     .opt_identifier => container_name[1..], // skip '?'
                                     else => unreachable,
                                 };
-                                var current_scope = scope;
+                                var current_scope = scope.?;
                                 const container_idx = while (true) {
                                     break schema_ast.scopes.get(current_scope).?.types.get(
                                         search_name,
@@ -2214,7 +2216,7 @@ pub fn validate(
                         switch (seen.*) {
                             .@"struct" => |*bits| {
                                 assert(expr.tag != .any_kw);
-                                const scope = schema_ast.scopes.get(scopes_stack.getLast()).?;
+                                const scope = schema_ast.scopes.get(scopes_stack.getLast().?).?;
                                 const field_slot = scope.fields.getIndex(name) orelse {
                                     try errors.append(gpa, .{
                                         .tag = .unknown_field,


### PR DESCRIPTION
- Pass through args change in build.zig
- Cleaned up some commentedd out code and whitespace (naughty, naughty)
- `getLast()` returns an optional

The `getLast()` changes are consistent with the old codepath, since that one was directly grabbing the last entry of the list.